### PR TITLE
Fix error with incorrect generated ranks in multiple policies

### DIFF
--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -254,11 +254,12 @@ locals {
 
   device_admin_authentication_rules = flatten([
     for ps in try(local.ise.device_administration.policy_sets, []) : [
-      for rule in try(ps.authentication_rules, []) : {
+      for generated_rank, rule in try(ps.authentication_rules, []) : {
         key                        = format("%s/%s", ps.name, rule.name)
         policy_set_id              = local.device_admin_policy_set_ids[ps.name]
         name                       = rule.name
         rank                       = try(rule.rank, local.defaults.ise.device_administration.policy_sets.authentication_rules.rank, null)
+        generated_rank             = generated_rank
         default                    = rule.name == "Default" ? true : false
         state                      = try(rule.state, local.defaults.ise.device_administration.policy_sets.authentication_rules.state, null)
         condition_type             = rule.name == "Default" ? null : try(rule.condition.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
@@ -297,11 +298,6 @@ locals {
     ]
   ])
 
-  device_admin_authentication_rules_with_ranks = [
-    for idx, rule in local.device_admin_authentication_rules : merge(rule, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_device_admin_authentication_rule" "device_admin_authentication_rule" {
@@ -343,7 +339,7 @@ resource "ise_device_admin_authentication_rule" "default_device_admin_authentica
 }
 
 resource "ise_device_admin_authentication_rule_update_rank" "device_admin_authentication_rule_update_rank" {
-  for_each = { for rule in local.device_admin_authentication_rules_with_ranks : rule.key => rule if rule.name != "Default" }
+  for_each = { for rule in local.device_admin_authentication_rules : rule.key => rule if rule.name != "Default" }
 
   policy_set_id = each.value.policy_set_id
   rule_id       = ise_device_admin_authentication_rule.device_admin_authentication_rule[each.value.key].id
@@ -365,11 +361,12 @@ resource "time_sleep" "device_admin_policy_object_wait" {
 locals {
   device_admin_authorization_rules = flatten([
     for ps in try(local.ise.device_administration.policy_sets, []) : [
-      for rule in try(ps.authorization_rules, []) : {
+      for generated_rank, rule in try(ps.authorization_rules, []) : {
         key                        = format("%s/%s", ps.name, rule.name)
         policy_set_id              = local.device_admin_policy_set_ids[ps.name]
         name                       = rule.name
         rank                       = try(rule.rank, local.defaults.ise.device_administration.policy_sets.authorization_rules.rank, null)
+        generated_rank             = generated_rank
         default                    = rule.name == "Default" ? true : false
         state                      = try(rule.state, local.defaults.ise.device_administration.policy_sets.authorization_rules.state, null)
         condition_type             = rule.name == "Default" ? null : try(rule.condition.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
@@ -406,11 +403,6 @@ locals {
     ]
   ])
 
-  device_admin_authorization_rules_with_ranks = [
-    for idx, rule in local.device_admin_authorization_rules : merge(rule, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_device_admin_authorization_rule" "device_admin_authorization_rule" {
@@ -448,7 +440,7 @@ resource "ise_device_admin_authorization_rule" "default_device_admin_authorizati
 }
 
 resource "ise_device_admin_authorization_rule_update_rank" "device_admin_authorization_rule_update_rank" {
-  for_each = { for rule in local.device_admin_authorization_rules_with_ranks : rule.key => rule if rule.name != "Default" }
+  for_each = { for rule in local.device_admin_authorization_rules : rule.key => rule if rule.name != "Default" }
 
   policy_set_id = each.value.policy_set_id
   rule_id       = ise_device_admin_authorization_rule.device_admin_authorization_rule[each.value.key].id
@@ -458,11 +450,12 @@ resource "ise_device_admin_authorization_rule_update_rank" "device_admin_authori
 locals {
   device_admin_authorization_exception_rules = flatten([
     for ps in try(local.ise.device_administration.policy_sets, []) : [
-      for rule in try(ps.authorization_exception_rules, []) : {
+      for generated_rank, rule in try(ps.authorization_exception_rules, []) : {
         key                        = format("%s/%s", ps.name, rule.name)
         policy_set_id              = local.device_admin_policy_set_ids[ps.name]
         name                       = rule.name
         rank                       = try(rule.rank, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.rank, null)
+        generated_rank             = generated_rank
         state                      = try(rule.state, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.state, null)
         condition_type             = try(rule.condition.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
         condition_id               = contains(local.known_conditions_device_admin, try(rule.condition.name, "")) ? ise_device_admin_condition.device_admin_condition[rule.condition.name].id : try(data.ise_device_admin_condition.device_admin_condition[rule.condition.name].id, null)
@@ -498,11 +491,6 @@ locals {
     ]
   ])
 
-  device_admin_authorization_exception_rules_with_ranks = [
-    for idx, rule in local.device_admin_authorization_exception_rules : merge(rule, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_device_admin_authorization_exception_rule" "device_admin_authorization_exception_rule" {
@@ -526,7 +514,7 @@ resource "ise_device_admin_authorization_exception_rule" "device_admin_authoriza
 }
 
 resource "ise_device_admin_authorization_exception_rule_update_rank" "device_admin_authorization_exception_rule_update_rank" {
-  for_each = { for rule in local.device_admin_authorization_exception_rules_with_ranks : rule.key => rule }
+  for_each = { for rule in local.device_admin_authorization_exception_rules : rule.key => rule }
 
   policy_set_id = each.value.policy_set_id
   rule_id       = ise_device_admin_authorization_exception_rule.device_admin_authorization_exception_rule[each.value.key].id

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -159,7 +159,7 @@ data "ise_device_admin_condition" "device_admin_condition" {
 
 locals {
   device_admin_policy_sets = [
-    for ps in try(local.ise.device_administration.policy_sets, []) : {
+    for generated_rank, ps in try(local.ise.device_administration.policy_sets, []) : {
       condition_type             = ps.name == "Default" ? null : try(ps.condition.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
       condition_is_negate        = ps.name == "Default" ? null : try(ps.condition.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
       condition_attribute_name   = ps.name == "Default" ? null : try(ps.condition.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
@@ -175,6 +175,7 @@ locals {
       state                      = try(ps.state, local.defaults.ise.device_administration.policy_sets.state)
       default                    = ps.name == "Default" ? true : false
       rank                       = try(ps.rank, local.defaults.ise.device_administration.policy_sets.rank, null)
+      generated_rank             = generated_rank
       children = try([for i in ps.condition.children : {
         attribute_name   = try(i.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
         attribute_value  = try(i.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -198,11 +199,6 @@ locals {
     }
   ]
 
-  device_admin_policy_sets_with_ranks = [
-    for idx, ps in local.device_admin_policy_sets : merge(ps, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_device_admin_policy_set" "device_admin_policy_set" {
@@ -239,7 +235,7 @@ resource "ise_device_admin_policy_set" "default_device_admin_policy_set" {
 }
 
 resource "ise_device_admin_policy_set_update_rank" "device_admin_policy_set_update_rank" {
-  for_each = { for ps in local.device_admin_policy_sets_with_ranks : ps.name => ps if ps.name != "Default" }
+  for_each = { for ps in local.device_admin_policy_sets : ps.name => ps if ps.name != "Default" }
 
   policy_set_id = ise_device_admin_policy_set.device_admin_policy_set[each.key].id
   rank          = each.value.generated_rank
@@ -523,9 +519,10 @@ resource "ise_device_admin_authorization_exception_rule_update_rank" "device_adm
 
 locals {
   device_admin_authorization_global_exception_rules = [
-    for rule in try(local.ise.device_administration.authorization_global_exception_rules, []) : {
+    for generated_rank, rule in try(local.ise.device_administration.authorization_global_exception_rules, []) : {
       name                       = rule.name
       rank                       = try(rule.rank, local.defaults.ise.device_administration.authorization_global_exception_rules.rank, null)
+      generated_rank             = generated_rank
       state                      = try(rule.state, local.defaults.ise.device_administration.authorization_global_exception_rules.state, null)
       condition_type             = try(rule.condition.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
       condition_id               = contains(local.known_conditions_device_admin, try(rule.condition.name, "")) ? ise_device_admin_condition.device_admin_condition[rule.condition.name].id : try(data.ise_device_admin_condition.device_admin_condition[rule.condition.name].id, null)
@@ -560,11 +557,6 @@ locals {
     }
   ]
 
-  device_admin_authorization_global_exception_rules_with_ranks = [
-    for idx, rule in local.device_admin_authorization_global_exception_rules : merge(rule, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_device_admin_authorization_global_exception_rule" "device_admin_authorization_global_exception_rule" {
@@ -587,7 +579,7 @@ resource "ise_device_admin_authorization_global_exception_rule" "device_admin_au
 }
 
 resource "ise_device_admin_authorization_global_exception_rule_update_rank" "device_admin_authorization_global_exception_rule_update_rank" {
-  for_each = { for rule in local.device_admin_authorization_global_exception_rules_with_ranks : rule.name => rule }
+  for_each = { for rule in local.device_admin_authorization_global_exception_rules : rule.name => rule }
 
   rule_id = ise_device_admin_authorization_global_exception_rule.device_admin_authorization_global_exception_rule[each.value.name].id
   rank    = each.value.generated_rank

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -275,7 +275,7 @@ data "ise_network_access_condition" "network_access_condition" {
 
 locals {
   network_access_policy_sets = [
-    for ps in try(local.ise.network_access.policy_sets, []) : {
+    for generated_rank, ps in try(local.ise.network_access.policy_sets, []) : {
       condition_type             = ps.name == "Default" ? null : try(ps.condition.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
       condition_is_negate        = ps.name == "Default" ? null : try(ps.condition.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
       condition_attribute_name   = ps.name == "Default" ? null : try(ps.condition.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
@@ -291,6 +291,7 @@ locals {
       state                      = try(ps.state, local.defaults.ise.network_access.policy_sets.state)
       default                    = ps.name == "Default" ? true : false
       rank                       = try(ps.rank, local.defaults.ise.network_access.policy_sets.rank, null)
+      generated_rank             = generated_rank
       children = try([for i in ps.condition.children : {
         attribute_name   = try(i.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null),
         attribute_value  = try(i.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -314,11 +315,6 @@ locals {
     }
   ]
 
-  network_access_policy_sets_with_ranks = [
-    for idx, ps in local.network_access_policy_sets : merge(ps, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_network_access_policy_set" "network_access_policy_set" {
@@ -355,7 +351,7 @@ resource "ise_network_access_policy_set" "default_network_access_policy_set" {
 }
 
 resource "ise_network_access_policy_set_update_rank" "network_access_policy_set_update_rank" {
-  for_each = { for ps in local.network_access_policy_sets_with_ranks : ps.name => ps if ps.name != "Default" }
+  for_each = { for ps in local.network_access_policy_sets : ps.name => ps if ps.name != "Default" }
 
   policy_set_id = ise_network_access_policy_set.network_access_policy_set[each.key].id
   rank          = each.value.generated_rank
@@ -625,9 +621,10 @@ resource "ise_network_access_authorization_exception_rule_update_rank" "network_
 
 locals {
   network_access_authorization_global_exception_rules = [
-    for rule in try(local.ise.network_access.authorization_global_exception_rules, []) : {
+    for generated_rank, rule in try(local.ise.network_access.authorization_global_exception_rules, []) : {
       name                       = rule.name
       rank                       = try(rule.rank, local.defaults.ise.network_access.authorization_global_exception_rules.rank, null)
+      generated_rank             = generated_rank
       state                      = try(rule.state, local.defaults.ise.network_access.authorization_global_exception_rules.state, null)
       condition_type             = try(rule.condition.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
       condition_id               = contains(local.known_conditions_network_access, try(rule.condition.name, "")) ? ise_network_access_condition.network_access_condition[rule.condition.name].id : try(data.ise_network_access_condition.network_access_condition[rule.condition.name].id, null)
@@ -662,11 +659,6 @@ locals {
     }
   ]
 
-  network_access_authorization_global_exception_rules_with_ranks = [
-    for idx, rule in local.network_access_authorization_global_exception_rules : merge(rule, {
-      generated_rank = idx
-    })
-  ]
 }
 
 resource "ise_network_access_authorization_global_exception_rule" "network_access_authorization_global_exception_rule" {
@@ -689,7 +681,7 @@ resource "ise_network_access_authorization_global_exception_rule" "network_acces
 }
 
 resource "ise_network_access_authorization_global_exception_rule_update_rank" "network_access_authorization_global_exception_rule_update_rank" {
-  for_each = { for rule in local.network_access_authorization_global_exception_rules_with_ranks : rule.name => rule }
+  for_each = { for rule in local.network_access_authorization_global_exception_rules : rule.name => rule }
 
   rule_id = ise_network_access_authorization_global_exception_rule.network_access_authorization_global_exception_rule[each.value.name].id
   rank    = each.value.generated_rank


### PR DESCRIPTION
Generated rank is created as a flat list, which works incorrectly when there are multiple policies. This fix change generated_rank to be counted from zero for every policy.