### PR TITLE
#28 add support for shell profile av-pairs

### DIFF
--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -122,9 +122,9 @@ resource "ise_authorization_profile" "authorization_profile" {
   advanced_attributes = try([for i in each.value.advanced_attributes : {
     attribute_left_dictionary_name  = try(split(":", i.name)[0], null)
     attribute_left_name             = try(split(":", i.name)[1], null)
-    attribute_right_value_type      = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? "AttributeValue" : (try(split(":", i.value)[1], null) != null ? "AdvancedDictionaryAttribute" : "AttributeValue"),
-    attribute_right_dictionary_name = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[0] : null),
-    attribute_right_name            = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[1] : null),
+    attribute_right_value_type      = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? "AttributeValue" : (try(split(":", i.value)[1], null) != null ? "AdvancedDictionaryAttribute" : "AttributeValue")
+    attribute_right_dictionary_name = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[0] : null)
+    attribute_right_name            = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[1] : null)
     attribute_right_value           = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? i.value : (try(split(":", i.value)[1], null) != null ? null : i.value)
   }], null)
 

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -77,6 +77,13 @@ resource "ise_allowed_protocols" "allowed_protocols" {
   preferred_eap_protocol                            = try(each.value.preferred_eap_protocol, local.defaults.ise.network_access.policy_elements.allowed_protocols.preferred_eap_protocol, null)
 }
 
+locals {
+  # Define patterns that should be treated as AttributeValue despite containing colons
+  attribute_value_patterns = [
+    "shell:priv-lvl=",     # Matches shell:priv-lvl=15 and similar
+  ]
+}
+
 resource "ise_authorization_profile" "authorization_profile" {
   for_each = { for profile in try(local.ise.network_access.policy_elements.authorization_profiles, []) : profile.name => profile }
 
@@ -115,10 +122,10 @@ resource "ise_authorization_profile" "authorization_profile" {
   advanced_attributes = try([for i in each.value.advanced_attributes : {
     attribute_left_dictionary_name  = try(split(":", i.name)[0], null)
     attribute_left_name             = try(split(":", i.name)[1], null)
-    attribute_right_value_type      = try(split(":", i.value)[1], null) != null ? "AdvancedDictionaryAttribute" : "AttributeValue"
-    attribute_right_dictionary_name = try(split(":", i.value)[1], null) != null ? split(":", i.value)[0] : null
-    attribute_right_name            = try(split(":", i.value)[1], null) != null ? split(":", i.value)[1] : null
-    attribute_right_value           = try(split(":", i.value)[1], null) != null ? null : i.value
+    attribute_right_value_type      = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? "AttributeValue" : (try(split(":", i.value)[1], null) != null ? "AdvancedDictionaryAttribute" : "AttributeValue"),
+    attribute_right_dictionary_name = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[0] : null),
+    attribute_right_name            = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? null : (try(split(":", i.value)[1], null) != null ? split(":", i.value)[1] : null),
+    attribute_right_value           = anytrue([for pattern in local.attribute_value_patterns : can(regex(pattern, i.value))]) ? i.value : (try(split(":", i.value)[1], null) != null ? null : i.value)
   }], null)
 
   lifecycle {

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -80,7 +80,7 @@ resource "ise_allowed_protocols" "allowed_protocols" {
 locals {
   # Define strings that should be treated as AttributeValue despite containing colons
   attribute_value_patterns = [
-    "shell:priv-lvl=",     # Matches shell:priv-lvl=15 and similar
+    "shell:priv-lvl=",
   ]
 }
 


### PR DESCRIPTION
## Issue

With input YAML:

```
---
ise:
  network_access:
    policy_elements:
      authorization_profiles:
        - name: AUTHZ_02
          description: Authorization profile for Device Admin
          access_type: ACCESS_ACCEPT
          advanced_attributes:
            - name: Cisco:cisco-av-pair
              value: shell:priv-lvl=15
```

Where the value `shell:priv-lvl=15` is a single string. 

The value `Cisco:cisco-av-pair` is split correctly based on the `:`.

The actual output of terraform plan is:

```
# module.ise.ise_authorization_profile.authorization_profile["AUTHZ_02"] will be created
+ resource "ise_authorization_profile" "authorization_profile" {
    + access_type                 = "ACCESS_ACCEPT"
    + advanced_attributes         = [
        + {
            + attribute_left_dictionary_name  = "Cisco"
            + attribute_left_name             = "cisco-av-pair"
            + attribute_right_dictionary_name = "shell"
            + attribute_right_name            = "priv-lvl=15"
            + attribute_right_value_type      = "AdvancedDictionaryAttribute"
          },
      ]
    + agentless_posture           = false
    + description                 = "Authorization profile for Device Admin"
    + easywired_session_candidate = false
    + id                          = (known after apply)
    + name                        = "AUTHZ_02"
    + neat                        = false
    + profile_name                = "Cisco"
    + service_template            = false
    + track_movement              = false
    + voice_domain_permission     = false
    + web_auth                    = false
  }
```

The desired output should be:

```
+ resource "ise_authorization_profile" "authorization_profile" {
      + access_type                 = "ACCESS_ACCEPT"
      + advanced_attributes         = [
          + {
              + attribute_left_dictionary_name  = "Cisco"
              + attribute_left_name             = "cisco-av-pair"
              + attribute_right_value          = "shell:priv-lvl=15"
              + attribute_right_value_type     = "AttributeValue"
            },
        ]
      + agentless_posture           = false
      + description                 = "Authorization profile for Device Admin"
      + easywired_session_candidate = false
      + id                          = (known after apply)
      + name                        = "AUTHZ_02"
      + neat                        = false
      + profile_name                = "Cisco"
      + service_template            = false
      + track_movement              = false
      + voice_domain_permission     = false
      + web_auth                    = false
    }
```

## Proposed Fix

Define a local `attribute_value_patterns` list that can be used to bypass the logic that splits based on the presence of `:`.