### PR TITLE
fix: support custom NDG type names via single-segment path attribute

### DIFF
--- a/ise_network_resources.tf
+++ b/ise_network_resources.tf
@@ -1,6 +1,6 @@
 locals {
   network_device_groups = [for group in try(local.ise.network_resources.network_device_groups, []) : {
-    name        = try(split("#", group.path)[0] == "All Device Types", false) ? "Device Type#${group.path}#${group.name}" : (try(split("#", group.path)[0] == "All Locations", false) ? "Location#${group.path}#${group.name}" : (try(split("#", group.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${group.path}" : (try(group.path, null) == null ? "${group.name}#${group.name}" : "${split("#", group.path)[0]}#${group.path}#${group.name}")))
+    name        = try(split("#", group.path)[0] == "All Device Types", false) ? "Device Type#${group.path}#${group.name}" : (try(split("#", group.path)[0] == "All Locations", false) ? "Location#${group.path}#${group.name}" : (try(split("#", group.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${group.path}" : (try(group.path, null) == null ? "${group.name}#${group.name}" : (length(split("#", group.path)) == 1 ? "${group.path}#${group.name}" : "${split("#", group.path)[0]}#${group.path}#${group.name}"))))
     description = try(group.description, local.defaults.ise.network_resources.network_device_groups.description, null)
     root_group  = try(split("#", group.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", group.path)[0] == "All Locations", false) ? "Location" : (try(split("#", group.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", group.path)[0], group.name)))
   }]
@@ -17,7 +17,7 @@ resource "ise_network_device_group" "network_device_group_0" {
 locals {
   network_device_groups_children = flatten([for p in try(local.ise.network_resources.network_device_groups, []) : [
     for c in try(p.children, []) : {
-      name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}")))
+      name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}" : (length(split("#", p.path)) == 1 ? "${p.path}#${p.name}#${c.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}"))))
       description = try(c.description, local.defaults.ise.network_resources.network_device_groups.description, null)
       root_group  = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", p.path)[0], p.name)))
     }
@@ -38,7 +38,7 @@ locals {
   network_device_groups_children_children = flatten([for p in try(local.ise.network_resources.network_device_groups, []) : [
     for c in try(p.children, []) : [
       for c2 in try(c.children, []) : {
-        name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}")))
+        name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}" : (length(split("#", p.path)) == 1 ? "${p.path}#${p.name}#${c.name}#${c2.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}"))))
         description = try(c2.description, local.defaults.ise.network_resources.network_device_groups.description, null)
         root_group  = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", p.path)[0], p.name)))
       }
@@ -61,7 +61,7 @@ locals {
     for c in try(p.children, []) : [
       for c2 in try(c.children, []) : [
         for c3 in try(c2.children, []) : {
-          name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}")))
+          name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}" : (length(split("#", p.path)) == 1 ? "${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}"))))
           description = try(c.description, local.defaults.ise.network_resources.network_device_groups.description, null)
           root_group  = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", p.path)[0], p.name)))
         }
@@ -86,7 +86,7 @@ locals {
       for c2 in try(c.children, []) : [
         for c3 in try(c2.children, []) : [
           for c4 in try(c3.children, []) : {
-            name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}")))
+            name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : (length(split("#", p.path)) == 1 ? "${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}"))))
             description = try(c.description, local.defaults.ise.network_resources.network_device_groups.description, null)
             root_group  = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", p.path)[0], p.name)))
           }
@@ -113,7 +113,7 @@ locals {
         for c3 in try(c2.children, []) : [
           for c4 in try(c3.children, []) : [
             for c5 in try(c4.children, []) : {
-              name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}")))
+              name        = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC#${p.path}" : (try(p.path, null) == null ? "${p.name}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : (length(split("#", p.path)) == 1 ? "${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}" : "${split("#", p.path)[0]}#${p.path}#${p.name}#${c.name}#${c2.name}#${c3.name}#${c4.name}#${c5.name}"))))
               description = try(c.description, local.defaults.ise.network_resources.network_device_groups.description, null)
               root_group  = try(split("#", p.path)[0] == "All Device Types", false) ? "Device Type" : (try(split("#", p.path)[0] == "All Locations", false) ? "Location" : (try(split("#", p.path)[0] == "Is IPSEC Device", false) ? "IPSEC" : try(split("#", p.path)[0], p.name)))
             }
@@ -136,6 +136,25 @@ resource "ise_network_device_group" "network_device_group_5" {
 
 locals {
   all_network_device_groups = concat(local.network_device_groups, local.network_device_groups_children, local.network_device_groups_children_children, local.network_device_groups_children_children_children, local.network_device_groups_children_children_children_children, local.network_device_groups_children_children_children_children_children)
+}
+
+# Build a lookup map from root NDG names to their type prefixes.
+# For built-in NDGs, the type is hardcoded (Device Type, Location, IPSEC).
+# For custom NDGs with a single-segment path, the path IS the type prefix.
+# This allows network_device_groups assignments to dynamically resolve the correct
+# ERS API format (e.g., "All Device Groups" -> "Device Group#All Device Groups").
+locals {
+  ndg_type_map = merge(
+    {
+      "All Device Types" = "Device Type"
+      "All Locations"    = "Location"
+      "Is IPSEC Device"  = "IPSEC"
+    },
+    { for group in try(local.ise.network_resources.network_device_groups, []) :
+      group.name => group.path
+      if try(group.path, null) != null && length(split("#", group.path)) == 1
+    }
+  )
 }
 
 # Workaround for ISE API issue where creating/deleting a network device immediately after creating/deleting a network device group fails
@@ -171,7 +190,7 @@ resource "ise_network_device" "network_device" {
   }], null)
   model_name = try(each.value.model_name, local.defaults.ise.network_resources.network_devices.model_name, null)
   network_device_groups = try(each.value.network_device_groups, null) == null ? null : [
-    for group in try(each.value.network_device_groups, []) : split("#", group)[0] == "All Device Types" ? "Device Type#${group}" : (split("#", group)[0] == "All Locations" ? "Location#${group}" : (split("#", group)[0] == "Is IPSEC Device" ? "IPSEC#${group}" : split("#", group)[0] == "DNAC" ? group : "${split("#", group)[0]}#${group}"))
+    for group in try(each.value.network_device_groups, []) : contains(keys(local.ndg_type_map), split("#", group)[0]) ? "${local.ndg_type_map[split("#", group)[0]]}#${group}" : (split("#", group)[0] == "DNAC" ? group : "${split("#", group)[0]}#${group}")
   ]
   software_version                                            = try(each.value.software_version, local.defaults.ise.network_resources.network_devices.software_version, null)
   profile_name                                                = try(each.value.profile_name, local.defaults.ise.network_resources.network_devices.profile_name, null)


### PR DESCRIPTION
## Summary

- Adds support for custom Network Device Group (NDG) type names using the existing `path` attribute on root-level NDG definitions
- Builds a dynamic type-to-root mapping for network device group assignments, replacing hardcoded checks
- Fixes incorrect NDG naming for custom NDG categories when deployed via Terraform

## Problem

ISE Network Device Groups have a type/category prefix (e.g., `Device Type`, `Location`, `IPSEC`) that is prepended to the group name in the ERS API format: `Type#RootGroup#ChildGroup`.

The module hardcodes the type-to-root mapping for built-in NDGs:
- `All Device Types` → `Device Type`
- `All Locations` → `Location`
- `Is IPSEC Device` → `IPSEC`

For custom NDG categories (e.g., a customer-defined category with type `Device Group` and root `All Device Groups`), the module has no way to determine the type prefix. It falls back to using the root group name as the type, producing `All Device Groups#All Device Groups` instead of the correct `Device Group#All Device Groups`.

This causes:
1. The DEVICE dictionary attribute registers as `All Device Groups` instead of `Device Group`, breaking all policy conditions that reference `DEVICE : Device Group`
2. Network device group assignments reference `All Device Groups#All Device Groups#...` which doesn't match any NDG in ISE's database

## Solution

**NDG name construction:** When a root-level NDG definition has a `path` attribute with a single segment (no `#` delimiter), the module now treats it as the NDG type/category name and constructs the ERS API name as `${path}#${name}` instead of `${name}#${name}`.

Example YAML:
```yaml
network_device_groups:
  - name: All Device Groups
    path: Device Group
    description: Special Permissions
    children:
      - name: EDC-Storage
        path: All Device Groups
```

Produces:
- Root: `Device Group#All Device Groups` (type=`Device Group`, root_group=`Device Group`)
- Child: `Device Group#All Device Groups#EDC-Storage`

**Device group assignments:** Adds a `ndg_type_map` local that dynamically builds the type-to-root mapping from the NDG definitions in the YAML. The network device resource uses this map to resolve custom NDG type prefixes for device group assignments, eliminating the need for hardcoded checks.