### PR TITLE
fix: resolve managed identity group IDs for internal user assignments

### DIFF
--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -134,8 +134,27 @@ resource "ise_user_identity_group" "user_identity_group_5" {
   depends_on = [ise_user_identity_group.user_identity_group_4]
 }
 
+locals {
+  user_identity_groups_managed_names = toset(flatten([
+    [for g in try(local.ise.identity_management.user_identity_groups, []) : g.name],
+    [for g in local.user_identity_groups_children : g.name],
+    [for g in local.user_identity_groups_children_children : g.name],
+    [for g in local.user_identity_groups_children_children_children : g.name],
+    [for g in local.user_identity_groups_children_children_children_children : g.name],
+    [for g in local.user_identity_groups_children_children_children_children_children : g.name],
+  ]))
+  user_identity_groups_managed_ids = merge(
+    { for k, v in ise_user_identity_group.user_identity_group_0 : k => v.id },
+    { for k, v in ise_user_identity_group.user_identity_group_1 : v.name => v.id },
+    { for k, v in ise_user_identity_group.user_identity_group_2 : v.name => v.id },
+    { for k, v in ise_user_identity_group.user_identity_group_3 : v.name => v.id },
+    { for k, v in ise_user_identity_group.user_identity_group_4 : v.name => v.id },
+    { for k, v in ise_user_identity_group.user_identity_group_5 : v.name => v.id },
+  )
+}
+
 data "ise_user_identity_group" "user_identity_group" {
-  for_each = toset(local.user_identity_groups)
+  for_each = setsubtract(toset(local.user_identity_groups), local.user_identity_groups_managed_names)
 
   name = each.value
 
@@ -155,7 +174,7 @@ resource "ise_internal_user" "internal_user" {
   first_name             = try(each.value.first_name, local.defaults.ise.identity_management.internal_users.first_name, null)
   last_name              = try(each.value.last_name, local.defaults.ise.identity_management.internal_users.last_name, null)
   change_password        = try(each.value.change_password, local.defaults.ise.identity_management.internal_users.change_password, null)
-  identity_groups        = length(try(each.value.user_identity_groups, [])) > 0 ? join(",", [for i in try(each.value.user_identity_groups, []) : data.ise_user_identity_group.user_identity_group[i].id]) : null
+  identity_groups        = length(try(each.value.user_identity_groups, [])) > 0 ? join(",", [for i in try(each.value.user_identity_groups, []) : contains(local.user_identity_groups_managed_names, i) ? local.user_identity_groups_managed_ids[i] : data.ise_user_identity_group.user_identity_group[i].id]) : null
   password_never_expires = try(each.value.password_never_expires, local.defaults.ise.identity_management.internal_users.password_never_expires, null)
   password_id_store      = try(each.value.password_id_store, local.defaults.ise.identity_management.internal_users.password_id_store, null)
 


### PR DESCRIPTION
## Summary

- Fixes internal user creation failure when users reference identity groups managed by the same module
- Adds a local that tracks managed identity group names and IDs across all nesting depths
- The `identity_groups` attribute on `ise_internal_user` now resolves managed group IDs directly instead of relying solely on data source lookups

## Problem

When an internal user's `user_identity_groups` list references an identity group that is defined in the same YAML data model (and therefore managed by the same Terraform module), the module attempts to resolve the group's ID via `data.ise_user_identity_group`. This data source performs a lookup against ISE at plan time.

On a fresh ISE deployment, these identity groups don't exist yet — they're being created in the same apply. The data source lookup fails because it can't find a group that hasn't been created yet.

## Solution

Adds two locals:
- `user_identity_groups_managed_names`: a set of all identity group names managed by the module across all 6 nesting depths
- `user_identity_groups_managed_ids`: a map from group name to resource ID for all managed groups

The `ise_internal_user` resource's `identity_groups` attribute now checks whether a referenced group name is in the managed set. If so, it resolves the ID from the managed resource directly. Otherwise, it falls back to the data source lookup for groups that exist in ISE but aren't managed by the module.

The `data.ise_user_identity_group` data source's `for_each` is updated to exclude managed group names, preventing unnecessary lookups for groups the module itself creates.

No additional `depends_on` is needed — `user_identity_groups_managed_ids` has implicit dependencies on the `ise_user_identity_group` resources via direct reference, `ise_internal_user` already has explicit `depends_on = [ise_user_identity_group.user_identity_group_5]`, and the data source already has `depends_on` on all 6 identity group resource tiers.