### PR TITLE
feat: add dictionary attribute support to network access dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ module "ise" {
 | [ise_network_access_authorization_rule_update_ranks.network_access_authorization_rule_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_authorization_rule_update_ranks) | resource |
 | [ise_network_access_condition.network_access_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_dictionary.network_access_dictionary](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary) | resource |
+| [ise_network_access_dictionary_attribute.network_access_dictionary_attribute](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary_attribute) | resource |
 | [ise_network_access_policy_set.default_network_access_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_policy_set) | resource |
 | [ise_network_access_policy_set.network_access_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_policy_set) | resource |
 | [ise_network_access_policy_set_update_ranks.network_access_policy_set_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_policy_set_update_ranks) | resource |

--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -169,6 +169,8 @@ defaults:
           dacl_type: IPV4
         dictionaries:
           attribute_type: ENTITY_ATTR
+          attributes:
+            direction_type: BOTH
       policy_sets:
         default: false
         state: enabled

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -257,6 +257,35 @@ resource "ise_network_access_dictionary" "network_access_dictionary" {
   dictionary_attr_type = try(each.value.attribute_type, local.defaults.ise.network_access.policy_elements.dictionaries.attribute_type, null)
 }
 
+locals {
+  network_access_dictionary_attributes = flatten([
+    for d in try(local.ise.network_access.policy_elements.dictionaries, []) : [
+      for a in try(d.attributes, []) : {
+        key             = "${d.name}/${a.name}"
+        dictionary_name = d.name
+        name            = a.name
+        description     = try(a.description, local.defaults.ise.network_access.policy_elements.dictionaries.attributes.description, null)
+        data_type       = try(a.data_type, local.defaults.ise.network_access.policy_elements.dictionaries.attributes.data_type, null)
+        direction_type  = try(a.direction_type, local.defaults.ise.network_access.policy_elements.dictionaries.attributes.direction_type, null)
+        internal_name   = try(a.internal_name, local.defaults.ise.network_access.policy_elements.dictionaries.attributes.internal_name, null)
+      }
+    ]
+  ])
+}
+
+resource "ise_network_access_dictionary_attribute" "network_access_dictionary_attribute" {
+  for_each = { for a in local.network_access_dictionary_attributes : a.key => a }
+
+  dictionary_name = each.value.dictionary_name
+  name            = each.value.name
+  description     = each.value.description
+  data_type       = each.value.data_type
+  direction_type  = each.value.direction_type
+  internal_name   = each.value.internal_name
+
+  depends_on = [ise_network_access_dictionary.network_access_dictionary]
+}
+
 resource "ise_network_access_time_and_date_condition" "network_access_time_and_date_condition" {
   for_each = { for c in try(local.ise.network_access.policy_elements.time_date_conditions, []) : c.name => c }
 


### PR DESCRIPTION
## Summary

- Adds `ise_network_access_dictionary_attribute` resource block that flattens attributes from nested YAML dictionary definitions
- Keyed by `dictionary_name/attribute_name` for unique resource addressing
- Adds `direction_type: BOTH` default for dictionary attributes
- Depends on parent `ise_network_access_dictionary` resources via `depends_on`

Closes #53

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: opus-4.6
- **AI Contribution**: ~95%
- **AI Reason**: generated module HCL for dictionary attributes
- **Human Oversight**: Code reviewed and approved by @ChristopherJHart

🤖 Generated with [Claude Code](https://claude.com/claude-code)