### PR TITLE
fix: restore children to _ref conditions using two-phase leaf/parent split

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ module "ise" {
 | [ise_device_admin_authorization_rule_update_ranks.device_admin_authorization_rule_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_authorization_rule_update_ranks) | resource |
 | [ise_device_admin_condition.device_admin_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
 | [ise_device_admin_condition.device_admin_condition_ref](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_leaf](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
 | [ise_device_admin_policy_set.default_device_admin_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set) | resource |
 | [ise_device_admin_policy_set.device_admin_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set) | resource |
 | [ise_device_admin_policy_set_update_ranks.ise_device_admin_policy_set_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set_update_ranks) | resource |
@@ -113,6 +114,7 @@ module "ise" {
 | [ise_network_access_authorization_rule_update_ranks.network_access_authorization_rule_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_authorization_rule_update_ranks) | resource |
 | [ise_network_access_condition.network_access_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_condition.network_access_condition_ref](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_leaf](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_dictionary.network_access_dictionary](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary) | resource |
 | [ise_network_access_dictionary_attribute.network_access_dictionary_attribute](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary_attribute) | resource |
 | [ise_network_access_policy_set.default_network_access_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_policy_set) | resource |

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ module "ise" {
 | [ise_device_admin_condition.device_admin_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
 | [ise_device_admin_condition.device_admin_condition_ref](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
 | [ise_device_admin_condition.device_admin_condition_ref_leaf](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_mid1](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_mid2](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_mid3](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_mid4](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
+| [ise_device_admin_condition.device_admin_condition_ref_mid5](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_condition) | resource |
 | [ise_device_admin_policy_set.default_device_admin_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set) | resource |
 | [ise_device_admin_policy_set.device_admin_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set) | resource |
 | [ise_device_admin_policy_set_update_ranks.ise_device_admin_policy_set_update_ranks](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_policy_set_update_ranks) | resource |
@@ -115,6 +120,11 @@ module "ise" {
 | [ise_network_access_condition.network_access_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_condition.network_access_condition_ref](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_condition.network_access_condition_ref_leaf](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_mid1](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_mid2](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_mid3](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_mid4](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
+| [ise_network_access_condition.network_access_condition_ref_mid5](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_condition) | resource |
 | [ise_network_access_dictionary.network_access_dictionary](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary) | resource |
 | [ise_network_access_dictionary_attribute.network_access_dictionary_attribute](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_dictionary_attribute) | resource |
 | [ise_network_access_policy_set.default_network_access_policy_set](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/network_access_policy_set) | resource |

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -27,9 +27,100 @@ locals {
       ]
     ])) == 0
   ])
+  # mid1: managed circular conditions whose ConditionReference children are all leaves
+  device_admin_conditions_circular_mid1_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_leaf_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_leaf_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid2: managed circular conditions NOT in leaf/mid1, whose ConditionReference children are all in leaf or mid1
+  device_admin_conditions_circular_mid2_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid1_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid1_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid3: managed circular conditions NOT in leaf/mid1/mid2, whose ConditionReference children are all in leaf/mid1/mid2
+  device_admin_conditions_circular_mid3_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid2_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid2_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid4: managed circular conditions NOT in leaf/mid1/mid2/mid3, whose ConditionReference children are all in leaf/mid1/mid2/mid3
+  device_admin_conditions_circular_mid4_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid2_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid3_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid2_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid3_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid5: managed circular conditions NOT in leaf/mid1/mid2/mid3/mid4, whose ConditionReference children are all in leaf/mid1/mid2/mid3/mid4
+  device_admin_conditions_circular_mid5_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid2_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid3_names, condition.name) &&
+    !contains(local.device_admin_conditions_circular_mid4_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid2_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid3_names, try(child.name, "")) &&
+      !contains(local.device_admin_conditions_circular_mid4_names, try(child.name, ""))
+    ]) == 0
+  ])
   device_admin_conditions_circular_parent_names = setsubtract(
-    local.device_admin_conditions_circular_managed_names,
-    local.device_admin_conditions_circular_leaf_names
+    setsubtract(setsubtract(setsubtract(setsubtract(setsubtract(
+      local.device_admin_conditions_circular_managed_names,
+      local.device_admin_conditions_circular_leaf_names),
+      local.device_admin_conditions_circular_mid1_names),
+      local.device_admin_conditions_circular_mid2_names),
+      local.device_admin_conditions_circular_mid3_names),
+    local.device_admin_conditions_circular_mid4_names),
+    local.device_admin_conditions_circular_mid5_names
   )
 }
 
@@ -118,6 +209,181 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
 }
 
+resource "ise_device_admin_condition" "device_admin_condition_ref_mid1" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_mid1_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf]
+}
+
+resource "ise_device_admin_condition" "device_admin_condition_ref_mid2" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_mid2_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf, ise_device_admin_condition.device_admin_condition_ref_mid1]
+}
+
+resource "ise_device_admin_condition" "device_admin_condition_ref_mid3" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_mid3_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf, ise_device_admin_condition.device_admin_condition_ref_mid1, ise_device_admin_condition.device_admin_condition_ref_mid2]
+}
+
+resource "ise_device_admin_condition" "device_admin_condition_ref_mid4" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_mid4_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf, ise_device_admin_condition.device_admin_condition_ref_mid1, ise_device_admin_condition.device_admin_condition_ref_mid2, ise_device_admin_condition.device_admin_condition_ref_mid3]
+}
+
+resource "ise_device_admin_condition" "device_admin_condition_ref_mid5" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_mid5_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf, ise_device_admin_condition.device_admin_condition_ref_mid1, ise_device_admin_condition.device_admin_condition_ref_mid2, ise_device_admin_condition.device_admin_condition_ref_mid3, ise_device_admin_condition.device_admin_condition_ref_mid4]
+}
+
 resource "ise_device_admin_condition" "device_admin_condition_ref" {
   for_each = {
     for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
@@ -143,7 +409,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : contains(local.device_admin_conditions_circular_mid5_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -154,7 +420,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : contains(local.device_admin_conditions_circular_mid4_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c2.name].id : contains(local.device_admin_conditions_circular_mid5_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -165,7 +431,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : contains(local.device_admin_conditions_circular_mid4_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c3.name].id : contains(local.device_admin_conditions_circular_mid5_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -176,7 +442,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : contains(local.device_admin_conditions_circular_mid4_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c4.name].id : contains(local.device_admin_conditions_circular_mid5_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -187,7 +453,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : contains(local.device_admin_conditions_circular_mid4_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c5.name].id : contains(local.device_admin_conditions_circular_mid5_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
           }]
         }]
       }]
@@ -198,7 +464,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
     create_before_destroy = true
   }
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf, ise_device_admin_condition.device_admin_condition_ref_mid1, ise_device_admin_condition.device_admin_condition_ref_mid2, ise_device_admin_condition.device_admin_condition_ref_mid3, ise_device_admin_condition.device_admin_condition_ref_mid4, ise_device_admin_condition.device_admin_condition_ref_mid5]
 }
 
 resource "ise_device_admin_condition" "device_admin_condition" {
@@ -226,7 +492,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_parent_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : contains(local.device_admin_conditions_circular_mid5_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c.name].id : contains(local.device_admin_conditions_circular_parent_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, data.ise_device_admin_condition.device_admin_condition_circular[c2.name].description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -392,6 +658,11 @@ locals {
   device_admin_all_condition_ids = merge(
     { for k, v in ise_device_admin_condition.device_admin_condition : k => v.id },
     { for k, v in ise_device_admin_condition.device_admin_condition_ref_leaf : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_mid1 : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_mid2 : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_mid3 : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_mid4 : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_mid5 : k => v.id },
     { for k, v in ise_device_admin_condition.device_admin_condition_ref : k => v.id }
   )
 }

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -17,7 +17,7 @@ locals {
     length([
       for child in try(condition.children, []) : child.name
       if try(child.type, null) == "ConditionReference" &&
-         contains(local.device_admin_conditions_circular_managed_names, try(child.name, ""))
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, ""))
     ]) == 0
   ])
   device_admin_conditions_circular_parent_names = setsubtract(

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -700,7 +700,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-        id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -709,7 +709,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -718,7 +718,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -727,7 +727,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -736,7 +736,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -745,7 +745,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -846,7 +846,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -855,7 +855,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -864,7 +864,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -873,7 +873,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -882,7 +882,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -891,7 +891,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1013,7 +1013,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1022,7 +1022,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1031,7 +1031,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1040,7 +1040,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1049,7 +1049,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1058,7 +1058,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1162,7 +1162,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1171,7 +1171,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1180,7 +1180,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1189,7 +1189,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1198,7 +1198,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1207,7 +1207,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1293,7 +1293,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-        id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1302,7 +1302,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1311,7 +1311,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1320,7 +1320,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1329,7 +1329,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1338,7 +1338,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -14,11 +14,18 @@ locals {
     for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
     condition.name
     if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
-    length([
-      for child in try(condition.children, []) : child.name
-      if try(child.type, null) == "ConditionReference" &&
-      contains(local.device_admin_conditions_circular_managed_names, try(child.name, ""))
-    ]) == 0
+    length(flatten([
+      # depth-1: direct ConditionReference children pointing to managed conditions
+      [for child in try(condition.children, []) : child.name
+        if try(child.type, null) == "ConditionReference" &&
+      contains(local.device_admin_conditions_circular_managed_names, try(child.name, ""))],
+      # depth-2: ConditionReference grandchildren pointing to managed conditions
+      [for child in try(condition.children, []) :
+        [for grandchild in try(child.children, []) : grandchild.name
+          if try(grandchild.type, null) == "ConditionReference" &&
+        contains(local.device_admin_conditions_circular_managed_names, try(grandchild.name, ""))]
+      ]
+    ])) == 0
   ])
   device_admin_conditions_circular_parent_names = setsubtract(
     local.device_admin_conditions_circular_managed_names,
@@ -108,10 +115,6 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
     }]
   }]
 
-  lifecycle {
-    create_before_destroy = true
-  }
-
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
 }
 
@@ -140,7 +143,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_parent_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -151,7 +154,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_parent_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -162,7 +165,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_parent_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -173,7 +176,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_parent_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -184,7 +187,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_parent_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
           }]
         }]
       }]
@@ -286,7 +289,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
     }]
   }]
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf]
 }
 
 resource "ise_allowed_protocols_tacacs" "allowed_protocols_tacacs" {

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 data "ise_device_admin_condition" "device_admin_condition_circular" {
-  for_each = toset(local.device_admin_conditions_circular_names)
+  for_each = setsubtract(toset(local.device_admin_conditions_circular_names), local.device_admin_conditions_circular_managed_names)
 
   name = each.value
 }
@@ -131,7 +131,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
   description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
   name             = each.key
   children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
-    description      = try(c.description, data.ise_device_admin_condition.device_admin_condition_circular[c.name].description, null)
+    description      = try(c.description, null)
     attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
     attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
     dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
@@ -140,9 +140,9 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_parent_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
-      description      = try(c2.description, data.ise_device_admin_condition.device_admin_condition_circular[c2.name].description, null)
+      description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
       attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
       dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
@@ -151,9 +151,9 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_parent_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
-        description      = try(c3.description, data.ise_device_admin_condition.device_admin_condition_circular[c3.name].description, null)
+        description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
         attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
         dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
@@ -162,9 +162,9 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_parent_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
-          description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
+          description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
           attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
           dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
@@ -173,9 +173,9 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_parent_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
-            description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
+            description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
             attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
             dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
@@ -184,7 +184,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_parent_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
           }]
         }]
       }]

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -177,7 +177,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -188,7 +188,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -199,7 +199,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
           }]
         }]
       }]
@@ -234,7 +234,55 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_mid1" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -269,7 +317,55 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_mid2" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -304,7 +400,55 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_mid3" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -339,7 +483,55 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_mid4" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -374,7 +566,55 @@ resource "ise_device_admin_condition" "device_admin_condition_ref_mid5" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : contains(local.device_admin_conditions_circular_mid4_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : contains(local.device_admin_conditions_circular_mid4_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : contains(local.device_admin_conditions_circular_mid4_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : contains(local.device_admin_conditions_circular_mid4_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -409,7 +649,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : contains(local.device_admin_conditions_circular_mid5_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_mid1_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c.name].id : contains(local.device_admin_conditions_circular_mid2_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c.name].id : contains(local.device_admin_conditions_circular_mid3_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c.name].id : contains(local.device_admin_conditions_circular_mid4_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c.name].id : contains(local.device_admin_conditions_circular_mid5_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c.name].id, null)) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -420,7 +660,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : contains(local.device_admin_conditions_circular_mid4_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c2.name].id : contains(local.device_admin_conditions_circular_mid5_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : contains(local.device_admin_conditions_circular_mid4_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c2.name].id : contains(local.device_admin_conditions_circular_mid5_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c2.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id, null)) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -431,7 +671,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : contains(local.device_admin_conditions_circular_mid4_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c3.name].id : contains(local.device_admin_conditions_circular_mid5_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : contains(local.device_admin_conditions_circular_mid4_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c3.name].id : contains(local.device_admin_conditions_circular_mid5_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c3.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id, null)) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -442,7 +682,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : contains(local.device_admin_conditions_circular_mid4_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c4.name].id : contains(local.device_admin_conditions_circular_mid5_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : contains(local.device_admin_conditions_circular_mid4_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c4.name].id : contains(local.device_admin_conditions_circular_mid5_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c4.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id, null)) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -453,7 +693,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : contains(local.device_admin_conditions_circular_mid4_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c5.name].id : contains(local.device_admin_conditions_circular_mid5_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : contains(local.device_admin_conditions_circular_mid4_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c5.name].id : contains(local.device_admin_conditions_circular_mid5_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c5.name].id : try(data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id, null)) : null
           }]
         }]
       }]
@@ -503,7 +743,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_parent_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_mid1_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c2.name].id : contains(local.device_admin_conditions_circular_mid2_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c2.name].id : contains(local.device_admin_conditions_circular_mid3_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c2.name].id : contains(local.device_admin_conditions_circular_mid4_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c2.name].id : contains(local.device_admin_conditions_circular_mid5_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c2.name].id : contains(local.device_admin_conditions_circular_parent_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, data.ise_device_admin_condition.device_admin_condition_circular[c3.name].description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -514,7 +754,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_parent_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_mid1_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c3.name].id : contains(local.device_admin_conditions_circular_mid2_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c3.name].id : contains(local.device_admin_conditions_circular_mid3_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c3.name].id : contains(local.device_admin_conditions_circular_mid4_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c3.name].id : contains(local.device_admin_conditions_circular_mid5_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c3.name].id : contains(local.device_admin_conditions_circular_parent_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -525,7 +765,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_parent_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_mid1_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c4.name].id : contains(local.device_admin_conditions_circular_mid2_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c4.name].id : contains(local.device_admin_conditions_circular_mid3_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c4.name].id : contains(local.device_admin_conditions_circular_mid4_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c4.name].id : contains(local.device_admin_conditions_circular_mid5_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c4.name].id : contains(local.device_admin_conditions_circular_parent_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -536,7 +776,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_parent_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_mid1_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c5.name].id : contains(local.device_admin_conditions_circular_mid2_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c5.name].id : contains(local.device_admin_conditions_circular_mid3_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c5.name].id : contains(local.device_admin_conditions_circular_mid4_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c5.name].id : contains(local.device_admin_conditions_circular_mid5_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c5.name].id : contains(local.device_admin_conditions_circular_parent_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
             children = length(try(c5.children, [])) == 0 ? null : [for c6 in try(c5.children, []) : {
               description      = try(c6.description, data.ise_device_admin_condition.device_admin_condition_circular[c6.name].description, null)
               attribute_name   = try(c6.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -547,7 +787,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
               is_negate        = try(c6.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
               operator         = try(c6.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
               name             = try(c6.name, null)
-              id               = try(c6.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c6.name].id : contains(local.device_admin_conditions_circular_parent_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref[c6.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c6.name].id) : null
+              id               = try(c6.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c6.name].id : contains(local.device_admin_conditions_circular_mid1_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_mid1[c6.name].id : contains(local.device_admin_conditions_circular_mid2_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_mid2[c6.name].id : contains(local.device_admin_conditions_circular_mid3_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_mid3[c6.name].id : contains(local.device_admin_conditions_circular_mid4_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_mid4[c6.name].id : contains(local.device_admin_conditions_circular_mid5_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_mid5[c6.name].id : contains(local.device_admin_conditions_circular_parent_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref[c6.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c6.name].id) : null
             }]
           }]
         }]
@@ -718,7 +958,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? local.device_admin_all_condition_ids[k.name] : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -727,7 +967,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? local.device_admin_all_condition_ids[l.name] : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -736,7 +976,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? local.device_admin_all_condition_ids[m.name] : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -745,7 +985,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? local.device_admin_all_condition_ids[n.name] : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -864,7 +1104,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? local.device_admin_all_condition_ids[k.name] : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -873,7 +1113,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? local.device_admin_all_condition_ids[l.name] : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -882,7 +1122,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? local.device_admin_all_condition_ids[m.name] : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -891,7 +1131,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? local.device_admin_all_condition_ids[n.name] : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1031,7 +1271,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? local.device_admin_all_condition_ids[k.name] : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1040,7 +1280,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? local.device_admin_all_condition_ids[l.name] : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1049,7 +1289,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? local.device_admin_all_condition_ids[m.name] : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1058,7 +1298,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? local.device_admin_all_condition_ids[n.name] : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1180,7 +1420,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? local.device_admin_all_condition_ids[k.name] : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1189,7 +1429,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? local.device_admin_all_condition_ids[l.name] : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1198,7 +1438,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? local.device_admin_all_condition_ids[m.name] : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1207,7 +1447,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? local.device_admin_all_condition_ids[n.name] : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1311,7 +1551,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? local.device_admin_all_condition_ids[k.name] : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1320,7 +1560,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? local.device_admin_all_condition_ids[l.name] : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1329,7 +1569,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? local.device_admin_all_condition_ids[m.name] : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1338,7 +1578,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? local.device_admin_all_condition_ids[n.name] : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)

--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -10,18 +10,32 @@ locals {
     for name in local.device_admin_conditions_circular_names : name
     if contains([for c in try(local.ise.device_administration.policy_elements.conditions, []) : c.name], name)
   ])
+  device_admin_conditions_circular_leaf_names = toset([
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.device_admin_conditions_circular_managed_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+         contains(local.device_admin_conditions_circular_managed_names, try(child.name, ""))
+    ]) == 0
+  ])
+  device_admin_conditions_circular_parent_names = setsubtract(
+    local.device_admin_conditions_circular_managed_names,
+    local.device_admin_conditions_circular_leaf_names
+  )
 }
 
 data "ise_device_admin_condition" "device_admin_condition_circular" {
-  for_each = setsubtract(toset(local.device_admin_conditions_circular_names), local.device_admin_conditions_circular_managed_names)
+  for_each = toset(local.device_admin_conditions_circular_names)
 
   name = each.value
 }
 
-resource "ise_device_admin_condition" "device_admin_condition_ref" {
+resource "ise_device_admin_condition" "device_admin_condition_ref_leaf" {
   for_each = {
     for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
-    if contains(local.device_admin_conditions_circular_managed_names, condition.name)
+    if contains(local.device_admin_conditions_circular_leaf_names, condition.name)
   }
 
   condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
@@ -33,12 +47,155 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
   operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
   description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
   name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, data.ise_device_admin_condition.device_admin_condition_circular[c.name].description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, data.ise_device_admin_condition.device_admin_condition_circular[c2.name].description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, data.ise_device_admin_condition.device_admin_condition_circular[c3.name].description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+          }]
+        }]
+      }]
+    }]
+  }]
 
   lifecycle {
     create_before_destroy = true
   }
 
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
+}
+
+resource "ise_device_admin_condition" "device_admin_condition_ref" {
+  for_each = {
+    for condition in try(local.ise.device_administration.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.device_admin_conditions_circular_parent_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.device_administration.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, data.ise_device_admin_condition.device_admin_condition_circular[c.name].description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, data.ise_device_admin_condition.device_admin_condition_circular[c2.name].description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, data.ise_device_admin_condition.device_admin_condition_circular[c3.name].description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.device_administration.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.device_administration.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+          }]
+        }]
+      }]
+    }]
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_device_admin_condition.device_admin_condition_ref_leaf]
 }
 
 resource "ise_device_admin_condition" "device_admin_condition" {
@@ -66,7 +223,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
     is_negate        = try(c.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c.name].id : contains(local.device_admin_conditions_circular_parent_names, c.name) ? ise_device_admin_condition.device_admin_condition_ref[c.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, data.ise_device_admin_condition.device_admin_condition_circular[c2.name].description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -77,7 +234,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
       is_negate        = try(c2.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c2.name].id : contains(local.device_admin_conditions_circular_parent_names, c2.name) ? ise_device_admin_condition.device_admin_condition_ref[c2.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, data.ise_device_admin_condition.device_admin_condition_circular[c3.name].description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -88,7 +245,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
         is_negate        = try(c3.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c3.name].id : contains(local.device_admin_conditions_circular_parent_names, c3.name) ? ise_device_admin_condition.device_admin_condition_ref[c3.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_device_admin_condition.device_admin_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -99,7 +256,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
           is_negate        = try(c4.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c4.name].id : contains(local.device_admin_conditions_circular_parent_names, c4.name) ? ise_device_admin_condition.device_admin_condition_ref[c4.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_device_admin_condition.device_admin_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -110,7 +267,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
             is_negate        = try(c5.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c5.name].id : contains(local.device_admin_conditions_circular_parent_names, c5.name) ? ise_device_admin_condition.device_admin_condition_ref[c5.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c5.name].id) : null
             children = length(try(c5.children, [])) == 0 ? null : [for c6 in try(c5.children, []) : {
               description      = try(c6.description, data.ise_device_admin_condition.device_admin_condition_circular[c6.name].description, null)
               attribute_name   = try(c6.attribute_name, local.defaults.ise.device_administration.policy_elements.conditions.attribute_name, null)
@@ -121,7 +278,7 @@ resource "ise_device_admin_condition" "device_admin_condition" {
               is_negate        = try(c6.is_negate, local.defaults.ise.device_administration.policy_elements.conditions.is_negate, null)
               operator         = try(c6.operator, local.defaults.ise.device_administration.policy_elements.conditions.operator, null)
               name             = try(c6.name, null)
-              id               = try(c6.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_managed_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref[c6.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c6.name].id) : null
+              id               = try(c6.type, local.defaults.ise.device_administration.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.device_admin_conditions_circular_leaf_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref_leaf[c6.name].id : contains(local.device_admin_conditions_circular_parent_names, c6.name) ? ise_device_admin_condition.device_admin_condition_ref[c6.name].id : data.ise_device_admin_condition.device_admin_condition_circular[c6.name].id) : null
             }]
           }]
         }]
@@ -231,6 +388,7 @@ locals {
   unknown_conditions_device_admin = setsubtract(local.unique_conditions_device_admin, local.known_conditions_device_admin)
   device_admin_all_condition_ids = merge(
     { for k, v in ise_device_admin_condition.device_admin_condition : k => v.id },
+    { for k, v in ise_device_admin_condition.device_admin_condition_ref_leaf : k => v.id },
     { for k, v in ise_device_admin_condition.device_admin_condition_ref : k => v.id }
   )
 }

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -337,7 +337,7 @@ resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
     }]
   }]
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
 }
 
 resource "ise_network_access_condition" "network_access_condition_ref_mid1" {

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -171,12 +171,87 @@ locals {
       !contains(local.network_access_conditions_circular_leaf_names, try(child.name, ""))
     ]) == 0
   ])
+  # mid2: managed circular conditions NOT in leaf/mid1, whose ConditionReference children are all in leaf or mid1
+  network_access_conditions_circular_mid2_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid1_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid1_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid3: managed circular conditions NOT in leaf/mid1/mid2, whose ConditionReference children are all in leaf/mid1/mid2
+  network_access_conditions_circular_mid3_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid2_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid2_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid4: managed circular conditions NOT in leaf/mid1/mid2/mid3, whose ConditionReference children are all in leaf/mid1/mid2/mid3
+  network_access_conditions_circular_mid4_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid2_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid3_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid2_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid3_names, try(child.name, ""))
+    ]) == 0
+  ])
+  # mid5: managed circular conditions NOT in leaf/mid1/mid2/mid3/mid4, whose ConditionReference children are all in leaf/mid1/mid2/mid3/mid4
+  network_access_conditions_circular_mid5_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_leaf_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid1_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid2_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid3_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_mid4_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_leaf_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid1_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid2_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid3_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_mid4_names, try(child.name, ""))
+    ]) == 0
+  ])
   network_access_conditions_circular_parent_names = setsubtract(
-    setsubtract(
+    setsubtract(setsubtract(setsubtract(setsubtract(setsubtract(
       local.network_access_conditions_circular_managed_names,
-      local.network_access_conditions_circular_leaf_names
-    ),
-    local.network_access_conditions_circular_mid1_names
+      local.network_access_conditions_circular_leaf_names),
+      local.network_access_conditions_circular_mid1_names),
+      local.network_access_conditions_circular_mid2_names),
+      local.network_access_conditions_circular_mid3_names),
+    local.network_access_conditions_circular_mid4_names),
+    local.network_access_conditions_circular_mid5_names
   )
 }
 
@@ -300,6 +375,146 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid1" {
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
 }
 
+resource "ise_network_access_condition" "network_access_condition_ref_mid2" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_mid2_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf, ise_network_access_condition.network_access_condition_ref_mid1]
+}
+
+resource "ise_network_access_condition" "network_access_condition_ref_mid3" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_mid3_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf, ise_network_access_condition.network_access_condition_ref_mid1, ise_network_access_condition.network_access_condition_ref_mid2]
+}
+
+resource "ise_network_access_condition" "network_access_condition_ref_mid4" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_mid4_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf, ise_network_access_condition.network_access_condition_ref_mid1, ise_network_access_condition.network_access_condition_ref_mid2, ise_network_access_condition.network_access_condition_ref_mid3]
+}
+
+resource "ise_network_access_condition" "network_access_condition_ref_mid5" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_mid5_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf, ise_network_access_condition.network_access_condition_ref_mid1, ise_network_access_condition.network_access_condition_ref_mid2, ise_network_access_condition.network_access_condition_ref_mid3, ise_network_access_condition.network_access_condition_ref_mid4]
+}
+
 resource "ise_network_access_condition" "network_access_condition_ref" {
   for_each = {
     for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
@@ -325,7 +540,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : contains(local.network_access_conditions_circular_mid5_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -336,7 +551,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : contains(local.network_access_conditions_circular_mid4_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c2.name].id : contains(local.network_access_conditions_circular_mid5_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -347,7 +562,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : contains(local.network_access_conditions_circular_mid4_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c3.name].id : contains(local.network_access_conditions_circular_mid5_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -358,7 +573,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : contains(local.network_access_conditions_circular_mid4_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c4.name].id : contains(local.network_access_conditions_circular_mid5_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -369,7 +584,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : contains(local.network_access_conditions_circular_mid4_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c5.name].id : contains(local.network_access_conditions_circular_mid5_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
           }]
         }]
       }]
@@ -380,7 +595,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
     create_before_destroy = true
   }
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf, ise_network_access_condition.network_access_condition_ref_mid1, ise_network_access_condition.network_access_condition_ref_mid2, ise_network_access_condition.network_access_condition_ref_mid3, ise_network_access_condition.network_access_condition_ref_mid4, ise_network_access_condition.network_access_condition_ref_mid5]
 }
 
 resource "ise_network_access_condition" "network_access_condition" {
@@ -408,7 +623,7 @@ resource "ise_network_access_condition" "network_access_condition" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : contains(local.network_access_conditions_circular_mid5_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -588,6 +803,10 @@ locals {
     { for k, v in ise_network_access_condition.network_access_condition : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref_leaf : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref_mid1 : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_mid2 : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_mid3 : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_mid4 : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_mid5 : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref : k => v.id }
   )
 }

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -158,7 +158,7 @@ locals {
 }
 
 data "ise_network_access_condition" "network_access_condition_circular" {
-  for_each = toset(local.network_access_conditions_circular_names)
+  for_each = setsubtract(toset(local.network_access_conditions_circular_names), local.network_access_conditions_circular_managed_names)
 
   name = each.value
 }
@@ -262,7 +262,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
   description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
   name             = each.key
   children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
-    description      = try(c.description, data.ise_network_access_condition.network_access_condition_circular[c.name].description, null)
+    description      = try(c.description, null)
     attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
     attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
     dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
@@ -271,9 +271,9 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
-      description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
+      description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
       attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
       dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
@@ -282,9 +282,9 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
-        description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
+        description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
         attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
         dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
@@ -293,9 +293,9 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
-          description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
+          description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
           attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
           dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
@@ -304,9 +304,9 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
-            description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
+            description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
             attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
             dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
@@ -315,7 +315,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
           }]
         }]
       }]

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -141,18 +141,32 @@ locals {
     for name in local.network_access_conditions_circular_names : name
     if contains([for c in try(local.ise.network_access.policy_elements.conditions, []) : c.name], name)
   ])
+  network_access_conditions_circular_leaf_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    length([
+      for child in try(condition.children, []) : child.name
+      if try(child.type, null) == "ConditionReference" &&
+         contains(local.network_access_conditions_circular_managed_names, try(child.name, ""))
+    ]) == 0
+  ])
+  network_access_conditions_circular_parent_names = setsubtract(
+    local.network_access_conditions_circular_managed_names,
+    local.network_access_conditions_circular_leaf_names
+  )
 }
 
 data "ise_network_access_condition" "network_access_condition_circular" {
-  for_each = setsubtract(toset(local.network_access_conditions_circular_names), local.network_access_conditions_circular_managed_names)
+  for_each = toset(local.network_access_conditions_circular_names)
 
   name = each.value
 }
 
-resource "ise_network_access_condition" "network_access_condition_ref" {
+resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
   for_each = {
     for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
-    if contains(local.network_access_conditions_circular_managed_names, condition.name)
+    if contains(local.network_access_conditions_circular_leaf_names, condition.name)
   }
 
   condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
@@ -164,12 +178,155 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
   operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
   description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
   name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, data.ise_network_access_condition.network_access_condition_circular[c.name].description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+          }]
+        }]
+      }]
+    }]
+  }]
 
   lifecycle {
     create_before_destroy = true
   }
 
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
+}
+
+resource "ise_network_access_condition" "network_access_condition_ref" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_parent_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, data.ise_network_access_condition.network_access_condition_circular[c.name].description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+          }]
+        }]
+      }]
+    }]
+  }]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
 }
 
 resource "ise_network_access_condition" "network_access_condition" {
@@ -197,7 +354,7 @@ resource "ise_network_access_condition" "network_access_condition" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -208,7 +365,7 @@ resource "ise_network_access_condition" "network_access_condition" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -219,7 +376,7 @@ resource "ise_network_access_condition" "network_access_condition" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -230,7 +387,7 @@ resource "ise_network_access_condition" "network_access_condition" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -241,7 +398,7 @@ resource "ise_network_access_condition" "network_access_condition" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
             children = length(try(c5.children, [])) == 0 ? null : [for c6 in try(c5.children, []) : {
               description      = try(c6.description, data.ise_network_access_condition.network_access_condition_circular[c6.name].description, null)
               attribute_name   = try(c6.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -252,7 +409,7 @@ resource "ise_network_access_condition" "network_access_condition" {
               is_negate        = try(c6.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
               operator         = try(c6.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
               name             = try(c6.name, null)
-              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_managed_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
+              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c6.name].id : contains(local.network_access_conditions_circular_parent_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
             }]
           }]
         }]
@@ -375,6 +532,7 @@ locals {
   unknown_conditions_network_access = setsubtract(local.unique_conditions_network_access, local.known_conditions_network_access)
   network_access_all_condition_ids = merge(
     { for k, v in ise_network_access_condition.network_access_condition : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_leaf : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref : k => v.id }
   )
 }

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -148,7 +148,7 @@ locals {
     length([
       for child in try(condition.children, []) : child.name
       if try(child.type, null) == "ConditionReference" &&
-         contains(local.network_access_conditions_circular_managed_names, try(child.name, ""))
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, ""))
     ]) == 0
   ])
   network_access_conditions_circular_parent_names = setsubtract(

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -308,7 +308,7 @@ resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -319,7 +319,7 @@ resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -330,7 +330,7 @@ resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
           }]
         }]
       }]
@@ -365,7 +365,55 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid1" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -400,7 +448,55 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid2" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -435,7 +531,55 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid3" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -470,7 +614,55 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid4" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -505,7 +697,55 @@ resource "ise_network_access_condition" "network_access_condition_ref_mid5" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
+    children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
+      description      = try(c2.description, null)
+      attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+      attribute_value  = try(c2.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+      dictionary_name  = try(c2.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+      dictionary_value = try(c2.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+      condition_type   = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+      is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+      operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+      name             = try(c2.name, null)
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : contains(local.network_access_conditions_circular_mid4_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
+      children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
+        description      = try(c3.description, null)
+        attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+        attribute_value  = try(c3.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+        dictionary_name  = try(c3.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+        dictionary_value = try(c3.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+        condition_type   = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+        is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+        operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+        name             = try(c3.name, null)
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : contains(local.network_access_conditions_circular_mid4_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
+        children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
+          description      = try(c4.description, null)
+          attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+          attribute_value  = try(c4.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+          dictionary_name  = try(c4.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+          dictionary_value = try(c4.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+          condition_type   = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+          is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+          operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+          name             = try(c4.name, null)
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : contains(local.network_access_conditions_circular_mid4_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
+          children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
+            description      = try(c5.description, null)
+            attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+            attribute_value  = try(c5.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+            dictionary_name  = try(c5.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+            dictionary_value = try(c5.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+            condition_type   = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+            is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+            operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+            name             = try(c5.name, null)
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : contains(local.network_access_conditions_circular_mid4_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
+          }]
+        }]
+      }]
+    }]
   }]
 
   lifecycle {
@@ -540,7 +780,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : contains(local.network_access_conditions_circular_mid5_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_mid2_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c.name].id : contains(local.network_access_conditions_circular_mid3_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c.name].id : contains(local.network_access_conditions_circular_mid4_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c.name].id : contains(local.network_access_conditions_circular_mid5_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c.name].id, null)) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -551,7 +791,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : contains(local.network_access_conditions_circular_mid4_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c2.name].id : contains(local.network_access_conditions_circular_mid5_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : contains(local.network_access_conditions_circular_mid4_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c2.name].id : contains(local.network_access_conditions_circular_mid5_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c2.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c2.name].id, null)) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -562,7 +802,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : contains(local.network_access_conditions_circular_mid4_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c3.name].id : contains(local.network_access_conditions_circular_mid5_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : contains(local.network_access_conditions_circular_mid4_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c3.name].id : contains(local.network_access_conditions_circular_mid5_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c3.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c3.name].id, null)) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -573,7 +813,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : contains(local.network_access_conditions_circular_mid4_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c4.name].id : contains(local.network_access_conditions_circular_mid5_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : contains(local.network_access_conditions_circular_mid4_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c4.name].id : contains(local.network_access_conditions_circular_mid5_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c4.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c4.name].id, null)) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -584,7 +824,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : contains(local.network_access_conditions_circular_mid4_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c5.name].id : contains(local.network_access_conditions_circular_mid5_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : contains(local.network_access_conditions_circular_mid4_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c5.name].id : contains(local.network_access_conditions_circular_mid5_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c5.name].id : try(data.ise_network_access_condition.network_access_condition_circular[c5.name].id, null)) : null
           }]
         }]
       }]
@@ -634,7 +874,7 @@ resource "ise_network_access_condition" "network_access_condition" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_mid2_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c2.name].id : contains(local.network_access_conditions_circular_mid3_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c2.name].id : contains(local.network_access_conditions_circular_mid4_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c2.name].id : contains(local.network_access_conditions_circular_mid5_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -645,7 +885,7 @@ resource "ise_network_access_condition" "network_access_condition" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_mid2_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c3.name].id : contains(local.network_access_conditions_circular_mid3_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c3.name].id : contains(local.network_access_conditions_circular_mid4_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c3.name].id : contains(local.network_access_conditions_circular_mid5_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -656,7 +896,7 @@ resource "ise_network_access_condition" "network_access_condition" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_mid2_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c4.name].id : contains(local.network_access_conditions_circular_mid3_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c4.name].id : contains(local.network_access_conditions_circular_mid4_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c4.name].id : contains(local.network_access_conditions_circular_mid5_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -667,7 +907,7 @@ resource "ise_network_access_condition" "network_access_condition" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_mid2_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c5.name].id : contains(local.network_access_conditions_circular_mid3_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c5.name].id : contains(local.network_access_conditions_circular_mid4_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c5.name].id : contains(local.network_access_conditions_circular_mid5_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
             children = length(try(c5.children, [])) == 0 ? null : [for c6 in try(c5.children, []) : {
               description      = try(c6.description, data.ise_network_access_condition.network_access_condition_circular[c6.name].description, null)
               attribute_name   = try(c6.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -678,7 +918,7 @@ resource "ise_network_access_condition" "network_access_condition" {
               is_negate        = try(c6.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
               operator         = try(c6.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
               name             = try(c6.name, null)
-              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c6.name].id : contains(local.network_access_conditions_circular_mid1_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c6.name].id : contains(local.network_access_conditions_circular_parent_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
+              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c6.name].id : contains(local.network_access_conditions_circular_mid1_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c6.name].id : contains(local.network_access_conditions_circular_mid2_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid2[c6.name].id : contains(local.network_access_conditions_circular_mid3_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid3[c6.name].id : contains(local.network_access_conditions_circular_mid4_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid4[c6.name].id : contains(local.network_access_conditions_circular_mid5_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid5[c6.name].id : contains(local.network_access_conditions_circular_parent_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
             }]
           }]
         }]
@@ -862,7 +1102,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? local.network_access_all_condition_ids[k.name] : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -871,7 +1111,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? local.network_access_all_condition_ids[l.name] : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -880,7 +1120,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? local.network_access_all_condition_ids[m.name] : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -889,7 +1129,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? local.network_access_all_condition_ids[n.name] : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -1008,7 +1248,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? local.network_access_all_condition_ids[k.name] : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1017,7 +1257,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? local.network_access_all_condition_ids[l.name] : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1026,7 +1266,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? local.network_access_all_condition_ids[m.name] : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1035,7 +1275,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? local.network_access_all_condition_ids[n.name] : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1233,7 +1473,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? local.network_access_all_condition_ids[k.name] : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1242,7 +1482,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? local.network_access_all_condition_ids[l.name] : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1251,7 +1491,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? local.network_access_all_condition_ids[m.name] : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1260,7 +1500,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? local.network_access_all_condition_ids[n.name] : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1394,7 +1634,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? local.network_access_all_condition_ids[k.name] : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1403,7 +1643,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? local.network_access_all_condition_ids[l.name] : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1412,7 +1652,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? local.network_access_all_condition_ids[m.name] : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1421,7 +1661,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? local.network_access_all_condition_ids[n.name] : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1537,7 +1777,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? local.network_access_all_condition_ids[k.name] : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1546,7 +1786,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? local.network_access_all_condition_ids[l.name] : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1555,7 +1795,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? local.network_access_all_condition_ids[m.name] : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1564,7 +1804,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? local.network_access_all_condition_ids[n.name] : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -145,15 +145,38 @@ locals {
     for condition in try(local.ise.network_access.policy_elements.conditions, []) :
     condition.name
     if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    length(flatten([
+      # depth-1: direct ConditionReference children pointing to managed conditions
+      [for child in try(condition.children, []) : child.name
+        if try(child.type, null) == "ConditionReference" &&
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, ""))],
+      # depth-2: ConditionReference grandchildren pointing to managed conditions
+      [for child in try(condition.children, []) :
+        [for grandchild in try(child.children, []) : grandchild.name
+          if try(grandchild.type, null) == "ConditionReference" &&
+        contains(local.network_access_conditions_circular_managed_names, try(grandchild.name, ""))]
+      ]
+    ])) == 0
+  ])
+  # mid1: managed circular conditions whose ConditionReference children are all leaves
+  network_access_conditions_circular_mid1_names = toset([
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) :
+    condition.name
+    if contains(local.network_access_conditions_circular_managed_names, condition.name) &&
+    !contains(local.network_access_conditions_circular_leaf_names, condition.name) &&
     length([
       for child in try(condition.children, []) : child.name
       if try(child.type, null) == "ConditionReference" &&
-      contains(local.network_access_conditions_circular_managed_names, try(child.name, ""))
+      contains(local.network_access_conditions_circular_managed_names, try(child.name, "")) &&
+      !contains(local.network_access_conditions_circular_leaf_names, try(child.name, ""))
     ]) == 0
   ])
   network_access_conditions_circular_parent_names = setsubtract(
-    local.network_access_conditions_circular_managed_names,
-    local.network_access_conditions_circular_leaf_names
+    setsubtract(
+      local.network_access_conditions_circular_managed_names,
+      local.network_access_conditions_circular_leaf_names
+    ),
+    local.network_access_conditions_circular_mid1_names
   )
 }
 
@@ -239,11 +262,42 @@ resource "ise_network_access_condition" "network_access_condition_ref_leaf" {
     }]
   }]
 
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
+}
+
+resource "ise_network_access_condition" "network_access_condition_ref_mid1" {
+  for_each = {
+    for condition in try(local.ise.network_access.policy_elements.conditions, []) : condition.name => condition
+    if contains(local.network_access_conditions_circular_mid1_names, condition.name)
+  }
+
+  condition_type   = try(each.value.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+  is_negate        = try(each.value.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+  attribute_name   = try(each.value.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+  attribute_value  = try(each.value.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+  dictionary_name  = try(each.value.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+  dictionary_value = try(each.value.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+  operator         = try(each.value.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+  description      = try(each.value.description, local.defaults.ise.network_access.policy_elements.conditions.description, null)
+  name             = each.key
+  children = length(try(each.value.children, [])) == 0 ? null : [for c in try(each.value.children, []) : {
+    description      = try(c.description, null)
+    attribute_name   = try(c.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
+    attribute_value  = try(c.attribute_value, local.defaults.ise.network_access.policy_elements.conditions.attribute_value, null)
+    dictionary_name  = try(c.dictionary_name, local.defaults.ise.network_access.policy_elements.conditions.dictionary_name, null)
+    dictionary_value = try(c.dictionary_value, local.defaults.ise.network_access.policy_elements.conditions.dictionary_value, null)
+    condition_type   = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null)
+    is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
+    operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
+    name             = try(c.name, null)
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+  }]
+
   lifecycle {
     create_before_destroy = true
   }
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
 }
 
 resource "ise_network_access_condition" "network_access_condition_ref" {
@@ -271,7 +325,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -282,7 +336,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -293,7 +347,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -304,7 +358,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -315,7 +369,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
           }]
         }]
       }]
@@ -354,7 +408,7 @@ resource "ise_network_access_condition" "network_access_condition" {
     is_negate        = try(c.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
     operator         = try(c.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
     name             = try(c.name, null)
-    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
+    id               = try(c.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c.name].id : contains(local.network_access_conditions_circular_mid1_names, c.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c.name].id : contains(local.network_access_conditions_circular_parent_names, c.name) ? ise_network_access_condition.network_access_condition_ref[c.name].id : data.ise_network_access_condition.network_access_condition_circular[c.name].id) : null
     children = length(try(c.children, [])) == 0 ? null : [for c2 in try(c.children, []) : {
       description      = try(c2.description, data.ise_network_access_condition.network_access_condition_circular[c2.name].description, null)
       attribute_name   = try(c2.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -365,7 +419,7 @@ resource "ise_network_access_condition" "network_access_condition" {
       is_negate        = try(c2.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
       operator         = try(c2.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
       name             = try(c2.name, null)
-      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
+      id               = try(c2.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c2.name].id : contains(local.network_access_conditions_circular_mid1_names, c2.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c2.name].id : contains(local.network_access_conditions_circular_parent_names, c2.name) ? ise_network_access_condition.network_access_condition_ref[c2.name].id : data.ise_network_access_condition.network_access_condition_circular[c2.name].id) : null
       children = length(try(c2.children, [])) == 0 ? null : [for c3 in try(c2.children, []) : {
         description      = try(c3.description, data.ise_network_access_condition.network_access_condition_circular[c3.name].description, null)
         attribute_name   = try(c3.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -376,7 +430,7 @@ resource "ise_network_access_condition" "network_access_condition" {
         is_negate        = try(c3.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
         operator         = try(c3.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
         name             = try(c3.name, null)
-        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
+        id               = try(c3.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c3.name].id : contains(local.network_access_conditions_circular_mid1_names, c3.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c3.name].id : contains(local.network_access_conditions_circular_parent_names, c3.name) ? ise_network_access_condition.network_access_condition_ref[c3.name].id : data.ise_network_access_condition.network_access_condition_circular[c3.name].id) : null
         children = length(try(c3.children, [])) == 0 ? null : [for c4 in try(c3.children, []) : {
           description      = try(c4.description, data.ise_network_access_condition.network_access_condition_circular[c4.name].description, null)
           attribute_name   = try(c4.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -387,7 +441,7 @@ resource "ise_network_access_condition" "network_access_condition" {
           is_negate        = try(c4.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
           operator         = try(c4.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
           name             = try(c4.name, null)
-          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
+          id               = try(c4.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c4.name].id : contains(local.network_access_conditions_circular_mid1_names, c4.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c4.name].id : contains(local.network_access_conditions_circular_parent_names, c4.name) ? ise_network_access_condition.network_access_condition_ref[c4.name].id : data.ise_network_access_condition.network_access_condition_circular[c4.name].id) : null
           children = length(try(c4.children, [])) == 0 ? null : [for c5 in try(c4.children, []) : {
             description      = try(c5.description, data.ise_network_access_condition.network_access_condition_circular[c5.name].description, null)
             attribute_name   = try(c5.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -398,7 +452,7 @@ resource "ise_network_access_condition" "network_access_condition" {
             is_negate        = try(c5.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
             operator         = try(c5.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
             name             = try(c5.name, null)
-            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
+            id               = try(c5.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c5.name].id : contains(local.network_access_conditions_circular_mid1_names, c5.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c5.name].id : contains(local.network_access_conditions_circular_parent_names, c5.name) ? ise_network_access_condition.network_access_condition_ref[c5.name].id : data.ise_network_access_condition.network_access_condition_circular[c5.name].id) : null
             children = length(try(c5.children, [])) == 0 ? null : [for c6 in try(c5.children, []) : {
               description      = try(c6.description, data.ise_network_access_condition.network_access_condition_circular[c6.name].description, null)
               attribute_name   = try(c6.attribute_name, local.defaults.ise.network_access.policy_elements.conditions.attribute_name, null)
@@ -409,7 +463,7 @@ resource "ise_network_access_condition" "network_access_condition" {
               is_negate        = try(c6.is_negate, local.defaults.ise.network_access.policy_elements.conditions.is_negate, null)
               operator         = try(c6.operator, local.defaults.ise.network_access.policy_elements.conditions.operator, null)
               name             = try(c6.name, null)
-              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c6.name].id : contains(local.network_access_conditions_circular_parent_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
+              id               = try(c6.type, local.defaults.ise.network_access.policy_elements.conditions.type, null) == "ConditionReference" ? (contains(local.network_access_conditions_circular_leaf_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_leaf[c6.name].id : contains(local.network_access_conditions_circular_mid1_names, c6.name) ? ise_network_access_condition.network_access_condition_ref_mid1[c6.name].id : contains(local.network_access_conditions_circular_parent_names, c6.name) ? ise_network_access_condition.network_access_condition_ref[c6.name].id : data.ise_network_access_condition.network_access_condition_circular[c6.name].id) : null
             }]
           }]
         }]
@@ -417,7 +471,7 @@ resource "ise_network_access_condition" "network_access_condition" {
     }]
   }]
 
-  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]
+  depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups, ise_network_access_condition.network_access_condition_ref_leaf]
 }
 
 resource "ise_downloadable_acl" "downloadable_acl" {
@@ -533,6 +587,7 @@ locals {
   network_access_all_condition_ids = merge(
     { for k, v in ise_network_access_condition.network_access_condition : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref_leaf : k => v.id },
+    { for k, v in ise_network_access_condition.network_access_condition_ref_mid1 : k => v.id },
     { for k, v in ise_network_access_condition.network_access_condition_ref : k => v.id }
   )
 }

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -844,7 +844,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-        id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -853,7 +853,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -862,7 +862,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -871,7 +871,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -880,7 +880,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -889,7 +889,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -990,7 +990,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -999,7 +999,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1008,7 +1008,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1017,7 +1017,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1026,7 +1026,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -1035,7 +1035,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1211,7 +1211,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
             attribute_value = (
@@ -1224,7 +1224,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1233,7 +1233,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1242,7 +1242,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1251,7 +1251,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -1260,7 +1260,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1372,7 +1372,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
             attribute_value = (
@@ -1385,7 +1385,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1394,7 +1394,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1403,7 +1403,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1412,7 +1412,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -1421,7 +1421,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1515,7 +1515,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-        id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name = try(j.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
           attribute_value = (
@@ -1528,7 +1528,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1537,7 +1537,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1546,7 +1546,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1555,7 +1555,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1564,7 +1564,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)


### PR DESCRIPTION
## Summary

Fixes #58

Circular managed conditions (`_ref`) were being created as permanent stubs without children since PR #49. This caused `terraform plan` to show the removal of all children from those conditions on every run.

**Root cause:** PR #49 solved the creation ordering problem by creating stub conditions first (no children). However, the stubs were never updated with their children — leaving them permanently childless from Terraform's perspective.

**Why restoring children is difficult:** Any approach using managed resource IDs directly hits a Terraform hard limit — a `for_each` resource cannot reference its own resource type within its own attribute blocks, regardless of instance keys. ISE itself prevents true circular references at the API level (`"The condition contains a library condition that refers back to it"`), confirmed via direct API testing, but Terraform's graph analysis still forbids intra-resource instance references.

**Fix:** Split circular managed conditions into two phases, mirroring how the module handles hierarchical NDGs:

- **`_ref_leaf`** — conditions whose children contain no `ConditionReference` to other managed circular conditions. Created first with full children. No self-reference issue.
- **`_ref` (parent)** — conditions whose children DO reference other managed circular conditions. Created second (`depends_on = [_ref_leaf]`) with full children. All `ConditionReference` IDs resolved via the `_circular` data source to avoid the self-reference error.

The `_circular` data source is expanded from `setsubtract` to `toset` so parent conditions can look up managed leaf condition IDs. Both `all_condition_ids` locals are updated to merge IDs from all three resources so policy sets resolve condition IDs correctly.

**Known limitation:** First-time creation of a parent→parent condition chain where neither condition yet exists in ISE will fail at plan time. Acceptable — ISE as Code manages existing deployments.

## Changes

- `ise_network_access.tf` — added `_ref_leaf` resource, split `_ref` into parent-only, expanded data source, updated `all_condition_ids` merge
- `ise_device_admin.tf` — same changes

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: root cause analysis, architectural investigation including direct ISE API testing to confirm no true circular references exist, implementation of two-phase split
- **Human Oversight**: Code reviewed, tested against live ISE deployment, and approved by camschae