### PR TITLE
fix: add url-redirect= to attribute_value_patterns to prevent colon split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.0.0 (unreleased)
 
 - Fix duplicate Terraform key error when defining multiple network device groups under the built-in `Is IPSEC Device` container [link](https://github.com/netascode/terraform-ise-nac-ise/pull/57)
+- Fix incorrect handling of advanced authorization profile attributes whose values contain a colon but are not `Dictionary:Attribute` pairs (e.g. `url-redirect=https://...`)
 
 ## 0.3.0
 

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -81,6 +81,7 @@ locals {
   # Define strings that should be treated as AttributeValue despite containing colons
   attribute_value_patterns = [
     "shell:priv-lvl=",
+    "url-redirect=",
   ]
 }
 


### PR DESCRIPTION
## Summary

fixes #61 

Authorization profile `advanced_attributes` values that start with `url-redirect=` (e.g. `url-redirect=https://portal.company.com/redirect`) contain a colon due to the `https://` scheme. The existing colon-based splitting logic incorrectly treats these as `Dictionary:Attribute` pairs and sends them as `AdvancedDictionaryAttribute`, causing an ISE API 400 error.

Adding `url-redirect=` to `attribute_value_patterns` forces these values to be treated as literal `AttributeValue`, matching the same fix already in place for `shell:priv-lvl=`.

**Broken YAML (before fix):**
```yaml
ise:
  network_access:
    policy_elements:
      authorization_profiles:
        - name: ProfileA
          advanced_attributes:
            - name: Cisco:cisco-av-pair
              value: "url-redirect=https://portal.company.com/redirect"
```
Without the fix, Terraform sends `attribute_right_value_type: AdvancedDictionaryAttribute` with `dictionary: url-redirect=https` and `attribute: //portal.company.com/redirect` — neither exist in ISE, causing apply to fail.

With the fix, Terraform correctly sends `attribute_right_value_type: AttributeValue` with `value: url-redirect=https://portal.company.com/redirect`.

## Test plan

- [x] `nac-validate` passes
- [x] `terraform apply` succeeds — plan confirms `attribute_right_value_type = "AttributeValue"`
- [x] ISE API confirms `rightHandSideAttribueValue.value = "url-redirect=https://portal.company.com/redirect"`
- [x] `terraform plan` idempotency — No changes

## Test results

### terraform apply
```
module.ise.ise_authorization_profile.authorization_profile["URL_REDIRECT_PROFILE"]: Creation complete

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.
```

Plan confirmed correct attribute handling:
```hcl
advanced_attributes = [
  {
    attribute_left_dictionary_name = "Cisco"
    attribute_left_name            = "cisco-av-pair"
    attribute_right_value          = "url-redirect=https://portal.company.com/redirect"
    attribute_right_value_type     = "AttributeValue"
  },
]
```

### ISE API verification
```json
{
  "leftHandSideDictionaryAttribue": {
    "dictionaryName": "Cisco",
    "attributeName": "cisco-av-pair"
  },
  "rightHandSideAttribueValue": {
    "AdvancedAttributeValueType": "AttributeValue",
    "value": "url-redirect=https://portal.company.com/redirect"
  }
}
```

### terraform plan idempotency
```
No changes. Your infrastructure matches the configuration.
```

### Robot Framework
31/32 tests passed. The 1 failure is a pre-existing bug in the `nac-ise` authorization profile Robot test template which uses the same colon-splitting logic — tracked separately in netascode/nac-ise.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: identified root cause, implemented fix, tested against live ISE
- **Human Oversight**: Code reviewed, tested against live ISE, and approved by camschae