### PR TITLE
fix(network_resources): ndg_type_map static entries must take precedence

### DIFF
--- a/ise_network_resources.tf
+++ b/ise_network_resources.tf
@@ -145,14 +145,14 @@ locals {
 # ERS API format (e.g., "All Device Groups" -> "Device Group#All Device Groups").
 locals {
   ndg_type_map = merge(
+    { for group in try(local.ise.network_resources.network_device_groups, []) :
+      group.name => group.path
+      if try(group.path, null) != null && length(split("#", group.path)) == 1
+    },
     {
       "All Device Types" = "Device Type"
       "All Locations"    = "Location"
       "Is IPSEC Device"  = "IPSEC"
-    },
-    { for group in try(local.ise.network_resources.network_device_groups, []) :
-      group.name => group.path
-      if try(group.path, null) != null && length(split("#", group.path)) == 1
     }
   )
 }


### PR DESCRIPTION
## Summary

Fixes #64

**Root cause:** `ndg_type_map` used `merge(static, dynamic)`. HCL's `merge()` gives later maps priority on duplicate keys. When a managed NDG entry (from the YAML's `network_device_groups` section) has the same `name` as a static entry — specifically `name: "Is IPSEC Device"` with `path: "Is IPSEC Device"` (a single-segment path that passes the dynamic filter) — the dynamic entry `"Is IPSEC Device" => "Is IPSEC Device"` overrides the static entry `"Is IPSEC Device" => "IPSEC"`.

**Impact:** Any network device whose `network_device_groups` includes an IPSEC hierarchy entry (e.g. `"Is IPSEC Device#Yes"`) had its group path constructed incorrectly: `"Is IPSEC Device#Is IPSEC Device#Yes"` instead of `"IPSEC#Is IPSEC Device#Yes"`. This produced a planned update on every plan run for every affected device.

**Fix:** Swap to `merge(dynamic, static)` so the static known-hierarchy entries always win on key conflicts.

## Changes

- `ise_network_resources.tf` — swap `ndg_type_map` merge argument order: dynamic first, static last

## Reproduction

**YAML config** (network_device_group with `path: "Is IPSEC Device"` triggers the conflict):

```yaml
ise:
  network_resources:
    network_device_groups:
      - name: Is IPSEC Device
        path: Is IPSEC Device
    network_devices:
      - name: TestIPSECDevice
        ips:
          - ip: 192.0.2.100
            mask: 32
        radius:
          shared_secret: Cisco123
        network_device_groups:
          - "Is IPSEC Device#Yes"
```

After importing `TestIPSECDevice` (ISE returns `IPSEC#Is IPSEC Device#Yes` as the group), run `terraform plan`:

## Test plan

Tested against ISE 3.4 with a network device in the `IPSEC#Is IPSEC Device#Yes` group.

**Before fix** — `network_device_groups` path corrupted on every plan:

```
# ise_network_device.network_device["TestIPSECDevice"] will be updated in-place
~ network_device_groups = [
  - "IPSEC#Is IPSEC Device#Yes"
  + "Is IPSEC Device#Is IPSEC Device#Yes"   ← wrong prefix
  ]
```

**After fix** — `IPSEC#Is IPSEC Device#Yes` is stable, no drift:

```
# ise_network_device.network_device["TestIPSECDevice"] will be updated in-place
~ network_device_groups = [
    # IPSEC#Is IPSEC Device#Yes   ← unchanged (1 unchanged element hidden)
  ]
  # Note: other group removals are test-setup artifacts, not related to this fix
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis and fix
- **Human Oversight**: Code reviewed, tested against live ISE 3.4 node, and approved by camschae