### PR TITLE
fix(conditions): preserve children on _ref conditions during brownfield import

### DIFF
--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -36,6 +36,7 @@ resource "ise_device_admin_condition" "device_admin_condition_ref" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [children]
   }
 
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -167,6 +167,7 @@ resource "ise_network_access_condition" "network_access_condition_ref" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [children]
   }
 
   depends_on = [ise_network_device_group.network_device_group_5, ise_active_directory_add_groups.active_directory_groups]


### PR DESCRIPTION
## Summary

Fixes #68

**Root cause:** The module splits conditions into two resources: `_ref` (created first as stubs to break circular dependencies, no `children` block) and regular conditions (created after, with full `children`). When a compound condition (`LibraryConditionAndBlock`) is also referenced by another condition as a `ConditionReference` child, it gets classified as `_ref`. After brownfield import, state has the children (captured from ISE). Config has no `children` block. Terraform plans to remove the children via PUT — ISE deletes them.

**Impact:** Any compound condition that is referenced by another condition has its children deleted from ISE on the first `terraform apply` after brownfield import.

**Fix:** Add `ignore_changes = [children]` to the lifecycle block of both `_ref` resources. For brownfield imports, existing children in state are preserved. For greenfield deployments, stubs are still created without children as before (circular dependency resolution is unchanged).

## Changes

- `ise_network_access.tf` — add `ignore_changes = [children]` to `network_access_condition_ref` lifecycle
- `ise_device_admin.tf` — add `ignore_changes = [children]` to `device_admin_condition_ref` lifecycle

## Reproduction

Create two conditions where one is a compound condition (`LibraryConditionAndBlock`) that is referenced by another:

**ISE setup** (via ERS API or ISE UI):
1. Create `ConditionA` — `LibraryConditionAndBlock` with two `ConditionAttributes` children
2. Create `ConditionB` — `LibraryConditionAndBlock` with a `ConditionReference` child pointing to `ConditionA`

**YAML config:**

```yaml
ise:
  network_access:
    policy_elements:
      conditions:
        - name: ConditionA
          type: LibraryConditionAndBlock
          children:
            - type: ConditionAttributes
              dictionary_name: Radius
              attribute_name: NAS-Port-Type
              operator: equals
              attribute_value: Wireless - IEEE 802.11
            - type: ConditionAttributes
              dictionary_name: Radius
              attribute_name: Called-Station-ID
              operator: contains
              attribute_value: Corp-SSID
        - name: ConditionB
          type: LibraryConditionAndBlock
          children:
            - type: ConditionReference
              name: ConditionA
            - type: ConditionAttributes
              dictionary_name: Radius
              attribute_name: NAS-Port-Type
              operator: equals
              attribute_value: Ethernet
```

## Test plan

Tested against ISE 3.4.

**Before fix** — children of the `_ref` condition planned for removal after import:

```
# ise_network_access_condition.network_access_condition_ref["ConditionA"] will be updated in-place
~ children = [
  - { attribute_name = "NAS-Port-Type", attribute_value = "Wireless - IEEE 802.11", ... },
  - { attribute_name = "Called-Station-ID", attribute_value = "Corp-SSID", ... },
  ] -> null
```

**After fix** — clean import, no changes:

```
Plan: 4 to import, 0 to change, 0 to destroy.
```

Confirmed with `terraform show -json` — `children` shows `after_unknown: true` (preserved, no removal planned).

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis, fix implementation, and test execution
- **Human Oversight**: Code reviewed, tested against live ISE 3.4 node, and approved by camschae