### PR TITLE
fix(defaults): remove aging_time default to prevent forced AD join point replacement

### DIFF
--- a/defaults/defaults.yaml
+++ b/defaults/defaults.yaml
@@ -57,7 +57,6 @@ defaults:
         enable_machine_access: true
         enable_dialin_permission_check: false
         plaintext_auth: false
-        aging_time: 5
         enable_callback_for_dialin_client: false
         enable_failed_auth_protection: false
         failed_auth_threshold: 5


### PR DESCRIPTION
## Summary

Fixes #71

**Root cause:** The module's `defaults/defaults.yaml` had `aging_time: 5` for active directories. When `aging_time` is not explicitly set in the YAML config, the module falls back to this default and passes `aging_time = 5` to the provider. For AD join points where ISE holds a different `agingTime` value, the provider plans a change — and since `aging_time` has `requires_replace: true`, this triggers a full destroy-and-recreate of the AD join point resource on every plan after brownfield import.

ISE bug CSCwu76772 also prevents writing `agingTime` via the API when `enableFailedAuthProtection = false` (common in many deployments), so the forced replacement would also fail on apply.

**Fix:** Remove `aging_time: 5` from the module defaults. The companion fix in the Terraform provider adds `write_changes_only: true` to `aging_time`, so the value is only sent to ISE when it actually changes. The ISE YAML is generated with the actual `agingTime` value from ISE, making config match state explicitly and eliminating the planned change.

## Changes

- `defaults/defaults.yaml` — remove `aging_time: 5` from active directories defaults

## Reproduction

**ISE setup:** An AD join point with `enableFailedAuthProtection = false` and `agingTime != 5` (e.g. `agingTime = 0`). Generate the YAML from ISE. Observe that `aging_time` is included in the YAML with the actual ISE value.

**YAML config** (aging_time included with actual ISE value):

```yaml
ise:
  identity_management:
    active_directories:
      - name: ExampleAD
        domain: example.com
        join_domain: false
        aging_time: 0
        enable_failed_auth_protection: false
```

## Test plan

Full brownfield pipeline tested (YAML generation → import → terraform plan) against ISE 3.4 with two AD join points:
- `agingTime=0, enableFailedAuthProtection=False`
- `agingTime=10, enableFailedAuthProtection=True`

**Before fix** (defaults.yaml had `aging_time: 5`):
```
# ise_active_directory_join_point["ExampleAD"] must be replaced
+/- resource "ise_active_directory_join_point" {
  ~ aging_time = 0 -> 5  # forces replacement
  }
Plan: 1 to import, 2 to add, 0 to change, 1 to destroy.
```

**After fix** (defaults removed, aging_time explicitly in YAML):
```
AD join point "ExampleAD": aging_time STABLE   ← no replacement
Plan: 1 to import, 1 to add, 0 to change, 0 to destroy.
```

**Greenfield (no aging_time in YAML):** provider `default_value: 5` applies → ISE receives 5 ✓

> **Note for operators:** Set `join_domain: false` in the YAML config for brownfield imports to prevent re-joining the AD domain.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis and fix
- **Human Oversight**: Code reviewed, full pipeline tested against live ISE 3.4, approved by camschae