### PR TITLE
fix: isolate id lookup errors in rule children blocks to prevent full children array collapse

### DIFF
--- a/ise_device_admin.tf
+++ b/ise_device_admin.tf
@@ -268,7 +268,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-        id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -277,7 +277,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -286,7 +286,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -295,7 +295,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -304,7 +304,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.condition.attribute_value, null)
@@ -313,7 +313,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -414,7 +414,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -423,7 +423,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -432,7 +432,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -441,7 +441,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -450,7 +450,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -459,7 +459,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authentication_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -581,7 +581,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -590,7 +590,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -599,7 +599,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -608,7 +608,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -617,7 +617,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -626,7 +626,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -730,7 +730,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -739,7 +739,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -748,7 +748,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -757,7 +757,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -766,7 +766,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -775,7 +775,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.device_administration.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -861,7 +861,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-        id               = contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : try(data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_device_admin, try(i.name, "")) ? local.device_admin_all_condition_ids[i.name] : data.ise_device_admin_condition.device_admin_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -870,7 +870,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : try(data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_device_admin, try(j.name, "")) ? local.device_admin_all_condition_ids[j.name] : data.ise_device_admin_condition.device_admin_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -879,7 +879,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : try(data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_device_admin, try(k.name, "")) ? ise_device_admin_condition.device_admin_condition[k.name].id : data.ise_device_admin_condition.device_admin_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -888,7 +888,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : try(data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_device_admin, try(l.name, "")) ? ise_device_admin_condition.device_admin_condition[l.name].id : data.ise_device_admin_condition.device_admin_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -897,7 +897,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : try(data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_device_admin, try(m.name, "")) ? ise_device_admin_condition.device_admin_condition[m.name].id : data.ise_device_admin_condition.device_admin_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.attribute_value, null)
@@ -906,7 +906,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.device_administration.authorization_global_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : try(data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_device_admin, try(n.name, "")) ? ise_device_admin_condition.device_admin_condition[n.name].id : data.ise_device_admin_condition.device_admin_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)

--- a/ise_network_access.tf
+++ b/ise_network_access.tf
@@ -412,7 +412,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-        id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name   = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
           attribute_value  = try(j.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -421,7 +421,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -430,7 +430,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -439,7 +439,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -448,7 +448,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.condition.attribute_value, null)
@@ -457,7 +457,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)
@@ -558,7 +558,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name   = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
             attribute_value  = try(j.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -567,7 +567,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -576,7 +576,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -585,7 +585,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -594,7 +594,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.attribute_value, null)
@@ -603,7 +603,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authentication_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -779,7 +779,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
             attribute_value = (
@@ -792,7 +792,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -801,7 +801,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -810,7 +810,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -819,7 +819,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.attribute_value, null)
@@ -828,7 +828,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -940,7 +940,7 @@ locals {
           condition_type   = try(i.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
           is_negate        = try(i.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
           operator         = try(i.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
           children = try([for j in i.children : {
             attribute_name = try(j.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
             attribute_value = (
@@ -953,7 +953,7 @@ locals {
             condition_type   = try(j.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
             is_negate        = try(j.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
             operator         = try(j.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
             children = try([for k in j.children : {
               attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
               attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -962,7 +962,7 @@ locals {
               condition_type   = try(k.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
               is_negate        = try(k.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
               operator         = try(k.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
               children = try([for l in k.children : {
                 attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -971,7 +971,7 @@ locals {
                 condition_type   = try(l.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                 is_negate        = try(l.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                 operator         = try(l.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
                 children = try([for m in l.children : {
                   attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -980,7 +980,7 @@ locals {
                   condition_type   = try(m.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                   is_negate        = try(m.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                   operator         = try(m.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                   children = try([for n in m.children : {
                     attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_name, null)
                     attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.attribute_value, null)
@@ -989,7 +989,7 @@ locals {
                     condition_type   = try(n.type, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.type, null)
                     is_negate        = try(n.is_negate, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.is_negate, null)
                     operator         = try(n.operator, local.defaults.ise.network_access.policy_sets.authorization_exception_rules.condition.operator, null)
-                    id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                    id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                   }], null)
                 }], null)
               }], null)
@@ -1083,7 +1083,7 @@ locals {
         condition_type   = try(i.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
         is_negate        = try(i.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
         operator         = try(i.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-        id               = contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : try(data.ise_network_access_condition.network_access_condition[i.name].id, null)
+        id               = try(contains(local.known_conditions_network_access, try(i.name, "")) ? local.network_access_all_condition_ids[i.name] : data.ise_network_access_condition.network_access_condition[i.name].id, null)
         children = try([for j in i.children : {
           attribute_name = try(j.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
           attribute_value = (
@@ -1096,7 +1096,7 @@ locals {
           condition_type   = try(j.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
           is_negate        = try(j.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
           operator         = try(j.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-          id               = contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : try(data.ise_network_access_condition.network_access_condition[j.name].id, null)
+          id               = try(contains(local.known_conditions_network_access, try(j.name, "")) ? local.network_access_all_condition_ids[j.name] : data.ise_network_access_condition.network_access_condition[j.name].id, null)
           children = try([for k in j.children : {
             attribute_name   = try(k.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
             attribute_value  = try(k.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1105,7 +1105,7 @@ locals {
             condition_type   = try(k.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
             is_negate        = try(k.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
             operator         = try(k.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-            id               = contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : try(data.ise_network_access_condition.network_access_condition[k.name].id, null)
+            id               = try(contains(local.known_conditions_network_access, try(k.name, "")) ? ise_network_access_condition.network_access_condition[k.name].id : data.ise_network_access_condition.network_access_condition[k.name].id, null)
             children = try([for l in k.children : {
               attribute_name   = try(l.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
               attribute_value  = try(l.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1114,7 +1114,7 @@ locals {
               condition_type   = try(l.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
               is_negate        = try(l.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
               operator         = try(l.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-              id               = contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : try(data.ise_network_access_condition.network_access_condition[l.name].id, null)
+              id               = try(contains(local.known_conditions_network_access, try(l.name, "")) ? ise_network_access_condition.network_access_condition[l.name].id : data.ise_network_access_condition.network_access_condition[l.name].id, null)
               children = try([for m in l.children : {
                 attribute_name   = try(m.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                 attribute_value  = try(m.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1123,7 +1123,7 @@ locals {
                 condition_type   = try(m.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                 is_negate        = try(m.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                 operator         = try(m.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                id               = contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : try(data.ise_network_access_condition.network_access_condition[m.name].id, null)
+                id               = try(contains(local.known_conditions_network_access, try(m.name, "")) ? ise_network_access_condition.network_access_condition[m.name].id : data.ise_network_access_condition.network_access_condition[m.name].id, null)
                 children = try([for n in m.children : {
                   attribute_name   = try(n.attribute_name, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_name, null)
                   attribute_value  = try(n.attribute_value, local.defaults.ise.network_access.authorization_global_exception_rules.condition.attribute_value, null)
@@ -1132,7 +1132,7 @@ locals {
                   condition_type   = try(n.type, local.defaults.ise.network_access.authorization_global_exception_rules.condition.type, null)
                   is_negate        = try(n.is_negate, local.defaults.ise.network_access.authorization_global_exception_rules.condition.is_negate, null)
                   operator         = try(n.operator, local.defaults.ise.network_access.authorization_global_exception_rules.condition.operator, null)
-                  id               = contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : try(data.ise_network_access_condition.network_access_condition[n.name].id, null)
+                  id               = try(contains(local.known_conditions_network_access, try(n.name, "")) ? ise_network_access_condition.network_access_condition[n.name].id : data.ise_network_access_condition.network_access_condition[n.name].id, null)
                 }], null)
               }], null)
             }], null)


### PR DESCRIPTION
## Summary

Fixes #63

**Root cause:** Authorization and authentication rules compute their `children` attribute using a `try([for i in rule.condition.children : { ... id = ... }], null)` pattern. The outer `try(..., null)` correctly handles rules with no children. However, any evaluation error on the `id` field for a single child propagates upward and triggers the outer guard, collapsing the entire `children` array to `null` — clearing all rule conditions in ISE on the next apply.

Two conditions trigger this:
1. **Key-not-found**: A condition is referenced by a rule and is being destroyed in the current plan without a replacement yet registered in `all_condition_ids`. The `all_condition_ids[name]` lookup throws a key-not-found error, caught by the outer `try()`.
2. **Unknown value propagation**: A condition is being created in the same plan as the rule update (for example, moving a condition to a new tier). Its ID is `(known after apply)`. In some Terraform versions this unknown value propagating through the outer `try()` expression triggers the `null` fallback.

**Fix:** Wrap each individual `id` lookup in its own `try(..., null)`:

```hcl
# Before — one bad id collapses the entire children array:
id = contains(local.known_conditions, try(i.name, "")) ?
     local.all_condition_ids[i.name] :
     try(data.ise_condition.condition[i.name].id, null)

# After — errors on individual id are isolated:
id = try(contains(local.known_conditions, try(i.name, "")) ?
     local.all_condition_ids[i.name] :
     data.ise_condition.condition[i.name].id, null)
```

Applied at all six depth levels for all rule types in `ise_network_access.tf` and `ise_device_admin.tf` (60 lines total).

## Changes

- `ise_network_access.tf` — wrap each `id` field lookup in `try(..., null)` at all 6 condition depth levels
- `ise_device_admin.tf` — same

## Reproduction

**Trigger scenario (key-not-found):**

```yaml
ise:
  network_access:
    policy_elements:
      conditions:
        - name: ConditionA
          type: LibraryConditionAttributes
          dictionary_name: Radius
          attribute_name: NAS-Port-Type
          operator: equals
          attribute_value: Wireless - IEEE 802.11
    policy_sets:
      - name: Default
        service_name: Default Network Access
        state: enabled
        authentication_rules:
          - name: RuleWithConditionRef
            identity_source_name: Internal Endpoints
            if_auth_fail: REJECT
            if_user_not_found: REJECT
            if_process_fail: DROP
            condition:
              type: ConditionAndBlock
              children:
                - type: ConditionReference
                  name: ConditionA
                - type: ConditionAttributes
                  dictionary_name: Radius
                  attribute_name: NAS-Port-Id
                  operator: contains
                  attribute_value: "11"
```

Remove `ConditionA` from the YAML and run `terraform plan` in the same cycle as the rule update. The `all_condition_ids["ConditionA"]` lookup fails, and with the old code the entire rule's `children` array collapses to `null`. On the next apply, ISE receives `children = null` and deletes all conditions from the rule.

## Test plan

This fix is structural/defensive. The exact edge case (condition being destroyed or having `(known after apply)` ID in the same plan as a rule update) is a timing condition in plan/apply cycles that is difficult to reproduce in isolation against a controlled ISE node.

The code change is clear: the outer `try()` is replaced by an inner `try()` on each individual `id` field, ensuring that a failure on one child's ID resolution produces `id = null` for that child only, not `children = null` for the entire rule.

Tested against ISE 3.4: a rule with a `ConditionReference` child imports and plans cleanly — children are preserved in both the old and new module versions when the condition ID is known at plan time.

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Root cause analysis and structural fix
- **Human Oversight**: Code reviewed and approved by camschae