### PR TITLE
fix(identity_management): omit group_id for dynamically-assigned endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ module "ise" {
 | [ise_device_admin_time_and_date_condition.device_admin_time_and_date_condition](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/device_admin_time_and_date_condition) | resource |
 | [ise_downloadable_acl.downloadable_acl](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/downloadable_acl) | resource |
 | [ise_endpoint.endpoint](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/endpoint) | resource |
+| [ise_endpoint.endpoint_static_group](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/endpoint) | resource |
 | [ise_endpoint_custom_attribute.endpoint_custom_attribute](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/endpoint_custom_attribute) | resource |
 | [ise_endpoint_identity_group.endpoint_identity_group_0](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/endpoint_identity_group) | resource |
 | [ise_endpoint_identity_group.endpoint_identity_group_1](https://registry.terraform.io/providers/CiscoDevNet/ise/latest/docs/resources/endpoint_identity_group) | resource |

--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -324,17 +324,60 @@ locals {
     { for k, v in ise_endpoint_identity_group.endpoint_identity_group_4 : k => v.id },
     { for k, v in ise_endpoint_identity_group.endpoint_identity_group_5 : k => v.id }
   )
+  endpoints = {
+    for endpoint in try(local.ise.identity_management.endpoints, []) : endpoint.mac => endpoint
+  }
+  endpoints_dynamic_group = {
+    for mac, endpoint in local.endpoints : mac => endpoint
+    if !try(endpoint.static_group_assignment, false)
+  }
+  endpoints_static_group = {
+    for mac, endpoint in local.endpoints : mac => endpoint
+    if try(endpoint.static_group_assignment, false)
+  }
 }
 
 resource "ise_endpoint" "endpoint" {
-  for_each = { for endpoint in try(local.ise.identity_management.endpoints, []) : endpoint.mac => endpoint }
+  for_each = local.endpoints_dynamic_group
 
   name                              = each.key
   mac                               = each.key
   description                       = try(each.value.description, local.defaults.ise.identity_management.endpoints.description, null)
   static_profile_assignment         = try(each.value.static_profile_assignment, local.defaults.ise.identity_management.endpoints.static_profile_assignment, null)
   static_group_assignment           = try(each.value.static_group_assignment, local.defaults.ise.identity_management.endpoints.static_group_assignment, null)
-  group_id                          = try(each.value.static_group_assignment, false) ? try(local.endpoint_identity_groups_all[each.value.endpoint_identity_group], data.ise_endpoint_identity_group.endpoint_identity_group[each.value.endpoint_identity_group].id, null) : null
+  static_profile_assignment_defined = try(each.value.static_profile_assignment_defined, local.defaults.ise.identity_management.endpoints.static_profile_assignment_defined, null)
+  static_group_assignment_defined   = try(each.value.static_group_assignment_defined, local.defaults.ise.identity_management.endpoints.static_group_assignment_defined, null)
+  identity_store                    = try(each.value.identity_store, local.defaults.ise.identity_management.endpoints.identity_store, null)
+  identity_store_id                 = try(each.value.identity_store_id, local.defaults.ise.identity_management.endpoints.identity_store_id, null)
+  portal_user                       = try(each.value.portal_user, local.defaults.ise.identity_management.endpoints.portal_user, null)
+  profile_id                        = try(each.value.static_profile_assignment, false) ? try(each.value.profile_id, local.defaults.ise.identity_management.endpoints.profile_id, null) : null
+  custom_attributes                 = try(each.value.custom_attributes, local.defaults.ise.identity_management.endpoints.custom_attributes, null)
+  mdm_compliance_status             = try(each.value.mdm_attributes.compliance_status, local.defaults.ise.identity_management.endpoints.mdm_attributes.compliance_status, null)
+  mdm_encrypted                     = try(each.value.mdm_attributes.encrypted, local.defaults.ise.identity_management.endpoints.mdm_attributes.encrypted, null)
+  mdm_enrolled                      = try(each.value.mdm_attributes.enrolled, local.defaults.ise.identity_management.endpoints.mdm_attributes.enrolled, null)
+  mdm_imei                          = try(each.value.mdm_attributes.imei, local.defaults.ise.identity_management.endpoints.mdm_attributes.imei, null)
+  mdm_jail_broken                   = try(each.value.mdm_attributes.jail_broken, local.defaults.ise.identity_management.endpoints.mdm_attributes.jail_broken, null)
+  mdm_manufacturer                  = try(each.value.mdm_attributes.manufacturer, local.defaults.ise.identity_management.endpoints.mdm_attributes.manufacturer, null)
+  mdm_model                         = try(each.value.mdm_attributes.model, local.defaults.ise.identity_management.endpoints.mdm_attributes.model, null)
+  mdm_os                            = try(each.value.mdm_attributes.os, local.defaults.ise.identity_management.endpoints.mdm_attributes.os, null)
+  mdm_phone_number                  = try(each.value.mdm_attributes.phone_number, local.defaults.ise.identity_management.endpoints.mdm_attributes.phone_number, null)
+  mdm_pinlock                       = try(each.value.mdm_attributes.pin_lock, local.defaults.ise.identity_management.endpoints.mdm_attributes.pin_lock, null)
+  mdm_reachable                     = try(each.value.mdm_attributes.reachable, local.defaults.ise.identity_management.endpoints.mdm_attributes.reachable, null)
+  mdm_serial                        = try(each.value.mdm_attributes.serial, local.defaults.ise.identity_management.endpoints.mdm_attributes.serial, null)
+  mdm_server_name                   = try(each.value.mdm_attributes.server_name, local.defaults.ise.identity_management.endpoints.mdm_attributes.server_name, null)
+
+  depends_on = [ise_endpoint_identity_group.endpoint_identity_group_5, ise_endpoint_custom_attribute.endpoint_custom_attribute]
+}
+
+resource "ise_endpoint" "endpoint_static_group" {
+  for_each = local.endpoints_static_group
+
+  name                              = each.key
+  mac                               = each.key
+  description                       = try(each.value.description, local.defaults.ise.identity_management.endpoints.description, null)
+  static_profile_assignment         = try(each.value.static_profile_assignment, local.defaults.ise.identity_management.endpoints.static_profile_assignment, null)
+  static_group_assignment           = try(each.value.static_group_assignment, local.defaults.ise.identity_management.endpoints.static_group_assignment, null)
+  group_id                          = try(local.endpoint_identity_groups_all[each.value.endpoint_identity_group], data.ise_endpoint_identity_group.endpoint_identity_group[each.value.endpoint_identity_group].id, null)
   static_profile_assignment_defined = try(each.value.static_profile_assignment_defined, local.defaults.ise.identity_management.endpoints.static_profile_assignment_defined, null)
   static_group_assignment_defined   = try(each.value.static_group_assignment_defined, local.defaults.ise.identity_management.endpoints.static_group_assignment_defined, null)
   identity_store                    = try(each.value.identity_store, local.defaults.ise.identity_management.endpoints.identity_store, null)


### PR DESCRIPTION
## Summary

Fixes #73

**Root cause:** The module set `group_id = null` when `static_group_assignment` is false. After brownfield import, ISE still holds a profiler-assigned group UUID in state. An explicit `null` in config causes perpetual `group_id` drift on every plan.

**Fix:** Split `ise_endpoint` into `endpoint` (dynamic group assignment) and `endpoint_static_group` (static group assignment). Only the static-group resource sets `group_id`.

**Note:** Endpoints move between resource addresses (`endpoint` vs `endpoint_static_group`) based on `static_group_assignment`. Brownfield deployments need corresponding import/state moves when adopting this change.

Companion provider fix: CiscoDevNet/terraform-provider-ise#242 (`group_id` Optional+Computed).

## Changes

- `ise_identity_management.tf` — split endpoint resources; omit `group_id` from dynamic-group instances
- `README.md` — regenerated with terraform-docs

## Test plan

```bash
terraform fmt ise_identity_management.tf
/tmp/terraform-docs .
terraform init -backend=false
terraform validate
```

```
Success! The configuration is valid, but there were some
validation warnings as shown above.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Brownfield import drift investigation
- **Human Oversight**: Code reviewed and approved by camschae

Made with [Cursor](https://cursor.com)