### PR TITLE
fix(ad): ignore groups drift on active_directory_join_point

### DIFF
--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -425,6 +425,12 @@ resource "ise_active_directory_join_point" "active_directory_join_point" {
   enable_failed_auth_protection     = try(each.value.enable_failed_auth_protection, local.defaults.ise.identity_management.active_directories.enable_failed_auth_protection, null)
   failed_auth_threshold             = try(each.value.failed_auth_threshold, local.defaults.ise.identity_management.active_directories.failed_auth_threshold, null)
   auth_protection_type              = try(each.value.auth_protection_type, local.defaults.ise.identity_management.active_directories.auth_protection_type, null)
+
+  lifecycle {
+    # Groups are managed by ise_active_directory_add_groups; import reads them on
+    # join_point but config intentionally sets groups = [].
+    ignore_changes = [groups]
+  }
 }
 
 resource "ise_active_directory_join_domain_with_all_nodes" "active_directory_join_domain_with_all_nodes" {


### PR DESCRIPTION
## Summary

Fixes #75

**Root cause:** `ise_active_directory_join_point` hardcodes `groups = []`, but brownfield import reads the full join point from ISE (including group memberships) into state. Groups are separately managed by `ise_active_directory_add_groups`, so the join point resource perpetually plans to clear `groups`.

**Fix:** Add `lifecycle { ignore_changes = [groups] }` on `ise_active_directory_join_point`.

## Changes

- `ise_identity_management.tf` — ignore `groups` on join point resource

## Test plan

```bash
terraform fmt ise_identity_management.tf
terraform init -backend=false
terraform validate
```

```
Success! The configuration is valid, but there were some
validation warnings as shown above.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Brownfield import drift investigation
- **Human Oversight**: Code reviewed and approved by camschae

Made with [Cursor](https://cursor.com)