### PR TITLE
feat(ise): expose custom_attributes in ise_internal_user

### DIFF
--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -158,6 +158,7 @@ resource "ise_internal_user" "internal_user" {
   identity_groups        = length(try(each.value.user_identity_groups, [])) > 0 ? join(",", [for i in try(each.value.user_identity_groups, []) : data.ise_user_identity_group.user_identity_group[i].id]) : null
   password_never_expires = try(each.value.password_never_expires, local.defaults.ise.identity_management.internal_users.password_never_expires, null)
   password_id_store      = try(each.value.password_id_store, local.defaults.ise.identity_management.internal_users.password_id_store, null)
+  custom_attributes      = try(jsonencode(each.value.custom_attributes), null)
 
   depends_on = [ise_user_identity_group.user_identity_group_5]
 }


### PR DESCRIPTION
## Summary

Fixes #78

**Root cause:** `custom_attributes` was absent from the `ise_internal_user` resource block. Any `custom_attributes` defined in the YAML data model were silently ignored and never passed to the provider.

**Fix:** Add `custom_attributes = try(jsonencode(each.value.custom_attributes), null)` to the `ise_internal_user` resource block. Uses `jsonencode` to convert the YAML map to a JSON string, matching the `String` type expected by the provider. `try(..., null)` follows the established module pattern — users without `custom_attributes` in their YAML get `null` (provider omits the field).

**Dependency:** Requires [CiscoDevNet/terraform-provider-ise#254](https://github.com/CiscoDevNet/terraform-provider-ise/pull/254) which fixes the provider to send `custom_attributes` as a raw JSON object rather than a quoted string.

## Changes

- `ise_identity_management.tf` — add `custom_attributes` to `ise_internal_user` resource block

## Test plan

```hcl
# YAML data model:
ise:
  identity_management:
    internal_users:
      - name: ExampleUser
        password: "C1sco12345!"
        custom_attributes:
          Department: Engineering
```

**terraform apply:**
```
module.ise.ise_internal_user.internal_user["ExampleUser"]: Creation complete after 0s
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

**terraform plan (idempotency):**
```
No changes. Your infrastructure matches the configuration.
```

**nac-test:**
```
✅ All tests passed: 9 out of 9 tests
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Module resource block addition
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae