### PR TITLE
feat(ise): expose custom_attributes in ise_internal_user

### DIFF
--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -158,6 +158,7 @@ resource "ise_internal_user" "internal_user" {
   identity_groups        = length(try(each.value.user_identity_groups, [])) > 0 ? join(",", [for i in try(each.value.user_identity_groups, []) : data.ise_user_identity_group.user_identity_group[i].id]) : null
   password_never_expires = try(each.value.password_never_expires, local.defaults.ise.identity_management.internal_users.password_never_expires, null)
   password_id_store      = try(each.value.password_id_store, local.defaults.ise.identity_management.internal_users.password_id_store, null)
+  custom_attributes      = try(each.value.custom_attributes, null)
 
   depends_on = [ise_user_identity_group.user_identity_group_5]
 }


### PR DESCRIPTION
## Summary

Fixes #78

**Root cause:** `custom_attributes` was absent from the `ise_internal_user` resource block in `ise_identity_management.tf`. Any YAML configuration that set `custom_attributes` on an internal user was silently ignored — the field was never passed to the provider, so no value was written to ISE.

**Fix:** Add `custom_attributes = try(each.value.custom_attributes, null)` to the `ise_internal_user` resource block. No `jsonencode()` is required — the provider accepts a native `Map of String`, so the YAML map value passes through directly.

## Changes

- `ise_identity_management.tf` — add `custom_attributes = try(each.value.custom_attributes, null)` to `ise_internal_user`

## Test plan

**pre-commit (all checks passed):**
```
Terraform fmt............................................................Passed
Terraform validate with tflint...........................................Passed
terraform-docs...........................................................Passed
terraform-docs...........................................................Passed
```

**Before fix:** `custom_attributes` was absent from the plan. The `Department` attribute was never written to ISE — the field was silently dropped by the module.

**After fix — terraform apply:**
```
  # module.ise.ise_internal_user.internal_user["BugTest_CustomAttr"] will be updated in-place
  ~ resource "ise_internal_user" "internal_user" {
      + custom_attributes      = {
          + "Department" = "Accounting"
        }
        id                     = "089ff579-11bf-4cda-b57b-76f509d258c9"
        name                   = "BugTest_CustomAttr"
        # (5 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

module.ise.ise_internal_user.internal_user["BugTest_CustomAttr"]: Modifying... [id=089ff579-11bf-4cda-b57b-76f509d258c9]
module.ise.ise_internal_user.internal_user["BugTest_CustomAttr"]: Modifications complete after 1s [id=089ff579-11bf-4cda-b57b-76f509d258c9]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```

**Idempotency — terraform plan:**
```
No changes. Your infrastructure matches the configuration.
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Code change and PR body
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae