### PR TITLE
fix(ise): remove lifecycle ignore_changes workaround from active_directory_join_point

### DIFF
--- a/ise_identity_management.tf
+++ b/ise_identity_management.tf
@@ -403,7 +403,6 @@ resource "ise_active_directory_join_point" "active_directory_join_point" {
   domain                     = try(each.value.domain, local.defaults.ise.identity_management.active_directories.domain, null)
   ad_scopes_names            = try(each.value.ad_scopes_names, local.defaults.ise.identity_management.active_directories.ad_scopes_names, null)
   enable_domain_allowed_list = try(each.value.enable_domain_allowed_list, local.defaults.ise.identity_management.active_directories.enable_domain_allowed_list, null)
-  groups                     = []
   attributes = [for attr in try(each.value.attributes, []) : {
     name          = try(attr.name, null)
     type          = try(attr.type, local.defaults.ise.identity_management.active_directories.attributes.type, null)
@@ -441,11 +440,6 @@ resource "ise_active_directory_join_point" "active_directory_join_point" {
   failed_auth_threshold             = try(each.value.failed_auth_threshold, local.defaults.ise.identity_management.active_directories.failed_auth_threshold, null)
   auth_protection_type              = try(each.value.auth_protection_type, local.defaults.ise.identity_management.active_directories.auth_protection_type, null)
 
-  lifecycle {
-    # Groups are managed by ise_active_directory_add_groups; import reads them on
-    # join_point but config intentionally sets groups = [].
-    ignore_changes = [groups]
-  }
 }
 
 resource "ise_active_directory_join_domain_with_all_nodes" "active_directory_join_domain_with_all_nodes" {


### PR DESCRIPTION
## Summary

Fixes #81

**Root cause:** PR #76 added `lifecycle { ignore_changes = [groups] }` and `groups = []` to the `ise_active_directory_join_point` resource as a workaround for brownfield import drift. ISE returns the associated groups in the GET response, so after import the state contained groups while the config had an explicit empty list — causing Terraform to plan a destroy/recreate on every subsequent plan.

**Fix:** The root cause is resolved in the provider by marking `groups` and `rewrite_rules` as `Computed: true` with a `PreserveStateIfUnconfigured` plan modifier (CiscoDevNet/terraform-provider-ise#261). When either attribute is omitted from config, the modifier preserves whatever is in state. The module-side workaround is no longer needed. The explicit `groups = []` is also removed because setting an explicit empty list bypasses the plan modifier — the modifier only activates when the attribute is `null` (omitted from config entirely).

**Impact:** No functional change for existing deployments. The lifecycle block becomes dead code once the provider fix is in place.

## Changes

- `ise_identity_management.tf` — remove `groups = []` and `lifecycle { ignore_changes = [groups] }` from `ise_active_directory_join_point`

## Test plan

Brownfield import of an `ise_active_directory_join_point` with three AD groups. Groups are provided in config with explicit SIDs alongside the full set of join point attributes.

**YAML config used:**

```yaml
ise:
  identity_management:
    active_directories:
      - name: AD-WithGroups1
        ad_username: Administrator
        domain: example.com
        join_domain: false
        ad_scopes_names: Default_Scope
        enable_domain_allowed_list: true
        groups:
          - name: example.com/org/Group/ISE
            sid: S-1-5-21-1234567890-1234567890-123456789-1001
          - name: example.com/org/Group/Infrastructure
            sid: S-1-5-21-1234567890-1234567890-123456789-1002
          - name: example.com/org/Group/Security
            sid: S-1-5-21-1234567890-1234567890-123456789-1003
        rewrite_rules:
          - row_id: 0
            rewrite_match: host/[HOSTNAME].[DOMAIN]
            rewrite_result: host/[HOSTNAME].[DOMAIN]
          - row_id: 1
            rewrite_match: host/[HOSTNAME]
            rewrite_result: host/[HOSTNAME]
          - row_id: 2
            rewrite_match: '[DOMAIN]\[IDENTITY]'
            rewrite_result: '[DOMAIN]\[IDENTITY]'
          - row_id: 3
            rewrite_match: '[IDENTITY]@[DOMAIN]'
            rewrite_result: '[IDENTITY]@[DOMAIN]'
          - row_id: 4
            rewrite_match: '[IDENTITY]'
            rewrite_result: '[IDENTITY]'
        enable_rewrites: false
        enable_pass_change: true
        enable_machine_auth: true
        enable_machine_access: true
        enable_dialin_permission_check: false
        plaintext_auth: false
        aging_time: 5
        enable_callback_for_dialin_client: false
        identity_not_in_ad_behaviour: SEARCH_JOINED_FOREST
        unreachable_domains_behaviour: PROCEED
        schema: CUSTOM
        first_name: givenNamea
        department: departmentt
        last_name: sn
        organizational_unit: company
        job_title: title
        locality: l
        email: mail
        state_or_province: st
        telephone: telephoneNumber
        country: co
        street_address: streetAddress
        enable_failed_auth_protection: true
        failed_auth_threshold: 15
        auth_protection_type: WIRED
```

**`terraform plan` + `terraform apply` (brownfield import):**

```
module.ise.ise_active_directory_join_point.active_directory_join_point["AD-WithGroups1"]: Preparing import... [id=<uuid>]
module.ise.ise_active_directory_join_point.active_directory_join_point["AD-WithGroups1"]: Refreshing state... [id=<uuid>]

  # module.ise.ise_active_directory_add_groups.active_directory_groups["AD-WithGroups1"] will be created
  + resource "ise_active_directory_add_groups" "active_directory_groups" {
      + ad_scopes_names            = "Default_Scope"
      + domain                     = "example.com"
      + enable_domain_allowed_list = true
      + groups                     = [
          + { name = "example.com/org/Group/ISE",            sid = "S-1-5-21-1234567890-1234567890-123456789-1001" },
          + { name = "example.com/org/Group/Infrastructure", sid = "S-1-5-21-1234567890-1234567890-123456789-1002" },
          + { name = "example.com/org/Group/Security",       sid = "S-1-5-21-1234567890-1234567890-123456789-1003" },
        ]
      + id                         = (known after apply)
      + join_point_id              = "<uuid>"
      + name                       = "AD-WithGroups1"
    }

  # module.ise.ise_active_directory_join_point.active_directory_join_point["AD-WithGroups1"] will be imported
    resource "ise_active_directory_join_point" "active_directory_join_point" {
        domain = "example.com"
        name   = "AD-WithGroups1"
        groups = [
            { name = "example.com/org/Group/ISE",            sid = "S-1-5-21-1234567890-1234567890-123456789-1001" },
            { name = "example.com/org/Group/Infrastructure", sid = "S-1-5-21-1234567890-1234567890-123456789-1002" },
            { name = "example.com/org/Group/Security",       sid = "S-1-5-21-1234567890-1234567890-123456789-1003" },
        ]
        ...
    }

Plan: 1 to import, 3 to add, 0 to change, 0 to destroy.

Apply complete! Resources: 1 imported, 3 added, 0 changed, 0 destroyed.
```

**`terraform plan` after apply — no drift:**

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

**Pre-commit checks:**

```
Terraform fmt............................................................Passed
Terraform validate with tflint...........................................Passed
terraform-docs...........................................................Passed
```

---
### 🤖 AI Generation Metadata

- **AI Generated**: Yes
- **AI Tool**: claude-code
- **AI Model**: claude-sonnet-4-6
- **AI Contribution**: ~80%
- **AI Reason**: Workaround removal, commit/PR preparation
- **Human Oversight**: Code reviewed, tested against live ISE node, and approved by camschae
